### PR TITLE
Explain repo contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,21 @@ webcomponents.js
 ================
 
 This repository contains the concatenated and minified form of the web component polyfills. The original source is located at [Polymer/webcomponentsjs-dev](https://github.com/Polymer/webcomponentsjs-dev), please post issues and pull requests there.
+
+## Web Component Polyfills
+
+* CustomElements.js - allows authors define their own custom tags.
+
+* HTMLImports.js - a way to include and reuse HTML documents in other HTML documents.
+
+* ShadowDOM.js - provides encapsulation by hiding DOM subtrees under shadow roots. 
+
+## webcomponents.js
+
+The concatenated and minified form of the web component polyfills.
+
+## webcomponents-lite.js
+
+The concatenated and minified form of just the Custom Element and HTML Import polyfills. This build does not contain support for Shadow DOM.
+
+


### PR DESCRIPTION
When a developer lands on this repository, they may want to understand the difference in what each file actually does. I certainly needed to dig around to understand the `lite` build.

This patch adds minimal explainers for the main files.
