### PR TITLE
Use the same casing as src

### DIFF
--- a/webcomponents.js
+++ b/webcomponents.js
@@ -60,7 +60,7 @@
   var ShadowDOMPolyfill = [
     'ShadowDOM/ShadowDOM.js',
     'WebComponents/shadowdom.js',
-    'ShadowCSS/ShadowCSS.js'
+    'ShadowCss/ShadowCSS.js'
   ];
 
   // select ShadowDOM impl


### PR DESCRIPTION
GitHub pages URLs are case-sensitive - “…/src/ShadowCSS/ShadowCSS.js” 404’s

I ran into this issue when I tried to seed gh-pages for `<paper-spinner>`
