### PR TITLE
Issue 32 - Drop MutationObserver polyfill for elements, imports

### DIFF
--- a/src/CustomElements/CustomElements.js
+++ b/src/CustomElements/CustomElements.js
@@ -7,10 +7,10 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 (function() {
-  
-// Estblish polyfill scope. We do this here to store flags. Flags are not 
+
+// Estblish polyfill scope. We do this here to store flags. Flags are not
 // supported in the build.
-window.CustomElements = window.CustomElements || {flags:{}};  
+window.CustomElements = window.CustomElements || {flags:{}};
 
 // Flags. Convert url arguments to flags
 var flags = {};
@@ -27,7 +27,6 @@ var file = 'CustomElements.js';
 
 var modules = [
   '../WeakMap/WeakMap.js',
-  '../MutationObserver/MutationObserver.js',
   'base.js',
   'traverse.js',
   'observe.js',
@@ -36,7 +35,7 @@ var modules = [
   'boot.js'
 ];
 
-var src = 
+var src =
   document.querySelector('script[src*="' + file + '"]').getAttribute('src');
 var basePath = src.slice(0, src.indexOf(file));
 
@@ -44,7 +43,7 @@ modules.forEach(function(f) {
   document.write('<script src="' + basePath + f + '"></script>');
 });
 
-// exports 
+// exports
 CustomElements.flags = flags;
 
 })();

--- a/src/CustomElements/build.json
+++ b/src/CustomElements/build.json
@@ -1,6 +1,5 @@
 [
   "../WeakMap/WeakMap.js",
-  "../MutationObserver/MutationObserver.js",
   "base.js",
   "traverse.js",
   "observe.js",

--- a/src/HTMLImports/HTMLImports.js
+++ b/src/HTMLImports/HTMLImports.js
@@ -8,9 +8,9 @@
  */
 (function() {
 
-// Estblish polyfill scope. We do this here to store flags. Flags are not 
+// Estblish polyfill scope. We do this here to store flags. Flags are not
 // supported in the build.
-window.HTMLImports = window.HTMLImports || {flags:{}};  
+window.HTMLImports = window.HTMLImports || {flags:{}};
 
 // Flags. Convert url arguments to flags
 var flags = {};
@@ -26,7 +26,6 @@ var file = 'HTMLImports.js';
 
 var modules = [
   '../WeakMap/WeakMap.js',
-  '../MutationObserver/MutationObserver.js',
   'base.js',
   'module.js',
   'path.js',
@@ -39,7 +38,7 @@ var modules = [
   'boot.js'
 ];
 
-var src = 
+var src =
   document.querySelector('script[src*="' + file + '"]').getAttribute('src');
 var basePath = src.slice(0, src.indexOf(file));
 
@@ -47,7 +46,7 @@ modules.forEach(function(f) {
   document.write('<script src="' + basePath + f + '"></script>');
 });
 
-// exports 
+// exports
 HTMLImports.flags = flags;
 
 })();

--- a/src/HTMLImports/build.json
+++ b/src/HTMLImports/build.json
@@ -1,6 +1,5 @@
 [
   "../WeakMap/WeakMap.js",
-  "../MutationObserver/MutationObserver.js",
   "base.js",
   "module.js",
   "path.js",


### PR DESCRIPTION
Quick fix to drop MutationObservers from being pulled in for CustomElements and HTMLImports polyfills. Feel free to close/comment if I've misunderstood where you wanted to avoid dead code being pulled in.