### PR TITLE
fixes #40: remove "use strict" from files where IE gets confused

### DIFF
--- a/src/ShadowDOM/wrappers/CanvasRenderingContext2D.js
+++ b/src/ShadowDOM/wrappers/CanvasRenderingContext2D.js
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 (function(scope) {
-  'use strict';
-
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
   var setWrapper = scope.setWrapper;

--- a/src/ShadowDOM/wrappers/WebGLRenderingContext.js
+++ b/src/ShadowDOM/wrappers/WebGLRenderingContext.js
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 (function(scope) {
-  'use strict';
-
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
   var setWrapper = scope.setWrapper;

--- a/src/ShadowDOM/wrappers/events.js
+++ b/src/ShadowDOM/wrappers/events.js
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 (function(scope) {
-  'use strict';
-
   var forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
   var getTreeScope = scope.getTreeScope;
   var mixin = scope.mixin;


### PR DESCRIPTION
Remove "use strict" from files that have assignments of the form `arguments[x] = y`, this pattern confuses IE 11.

Another option would be to copy the array so IE is more happy. I'm not sure which solution is more performant/better. Do any engines optimize strict mode? If they do, I'd hate to have events.js lose that. OTOH, the extra copy seemes unfortunate. And other polyfill & polymer code don't generally use strict mode. Though I personally think it's pretty neat.

@arv do you have any thoughts?
