### PR TITLE
Copy CustomElement's polyfill of CustomEvent to HTMLImports

### DIFF
--- a/src/HTMLImports/boot.js
+++ b/src/HTMLImports/boot.js
@@ -24,16 +24,15 @@ if (scope.useNative) {
   return;
 }
 
-// IE shim for CustomEvent
+// CustomEvent shim for IE
 if (typeof window.CustomEvent !== 'function') {
-  window.CustomEvent = function(inType, dictionary) {
-    var e = document.createEvent('HTMLEvents');
-    e.initEvent(inType,
-      dictionary.bubbles === false ? false : true,
-      dictionary.cancelable === false ? false : true,
-      dictionary.detail);
+  window.CustomEvent = function(inType, params) {
+    params = params || {};
+    var e = document.createEvent('CustomEvent');
+    e.initCustomEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable), params.detail);
     return e;
   };
+  window.CustomEvent.prototype = window.Event.prototype;
 }
 
 // Initialize polyfill modules. Note, polyfill modules are loaded but not 


### PR DESCRIPTION
This still unnecessarily polyfills the `CustomEvent` constructor on Safari (since `typeof CustomEvent === 'object'` on Safari), but now it creates a `CustomEvent` (with a proper `event.detail` property) and not a generic `Event` with no `event.detail`.
