### PR TITLE
Allow defining of flags in the global scope

### DIFF
--- a/src/WebComponents/build/boot.js
+++ b/src/WebComponents/build/boot.js
@@ -19,7 +19,6 @@ window.WebComponents = window.WebComponents || {};
   var script = document.querySelector('script[src*="' + file + '"]');
 
   // Flags. Convert url arguments to flags
-  var flags = {};
   if (!flags.noOpts) {
     // from url
     location.search.slice(1).split('&').forEach(function(o) {


### PR DESCRIPTION
Line 16 pulls in flags from the global scope so that you can define flags in a script tag as outlined in https://www.polymer-project.org/docs/polymer/runtime-config.html however the line removed in this pull request overwrites the local variable such that the flags in the global scope are ignored.
