### PR TITLE
Update URLs from Polymer org to WC org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This also folds in polyfills for `MutationObserver` and `WeakMap`.
 
 ## Releases
 
-Pre-built (concatenated & minified) versions of the polyfills are maintained in the [tagged versions](https://github.com/Polymer/webcomponentsjs/releases) of this repo. There are two variants:
+Pre-built (concatenated & minified) versions of the polyfills are maintained in the [tagged versions](https://github.com/webcomponents/webcomponentsjs/releases) of this repo. There are two variants:
 
 `webcomponents.js` includes all of the polyfills.
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "webcomponentsjs",
   "main": "webcomponents.js",
-  "version": "0.4.2",
+  "version": "0.5.1",
   "homepage": "http://webcomponents.org",
   "authors": [
     "The Polymer Authors"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Polymer/webcomponentsjs.git"
+    "url": "https://github.com/webcomponents/webcomponentsjs.git"
   },
   "author": "The Polymer Authors",
   "license": {
@@ -16,7 +16,7 @@
     "url": "http://polymer.github.io/LICENSE.txt"
   },
   "bugs": {
-    "url": "https://github.com/Polymer/webcomponentsjs/issues"
+    "url": "https://github.com/webcomponents/webcomponentsjs/issues"
   },
   "homepage": "http://webcomponents.org",
   "devDependencies": {

--- a/src/ShadowCSS/ShadowCSS.js
+++ b/src/ShadowCSS/ShadowCSS.js
@@ -515,7 +515,7 @@ var ShadowCSS = {
           rule.style.content + '\';');
     }
     // TODO(sorvell): we can workaround this issue here, but we need a list
-    // of troublesome properties to fix https://github.com/Polymer/platform/issues/53
+    // of troublesome properties to fix https://github.com/webcomponents/webcomponentsjs/issues/9
     //
     // inherit rules can be omitted from cssText
     // TODO(sorvell): remove when Blink bug is fixed:


### PR DESCRIPTION
FYI there are still lots of references to "The Polymer Authors" and licenses.

P.S.: Also updated version on bower.json file.