### PR TITLE
Fix bug in IE10 with MutationObserver

### DIFF
--- a/src/MutationObserver/MutationObserver.js
+++ b/src/MutationObserver/MutationObserver.js
@@ -524,7 +524,6 @@
           // Fall through.
         case 'DOMNodeInserted':
           // http://dom.spec.whatwg.org/#concept-mo-queue-childlist
-          var target = e.relatedNode;
           var changedNode = e.target;
           var addedNodes, removedNodes;
           if (e.type === 'DOMNodeInserted') {
@@ -539,13 +538,13 @@
           var nextSibling = changedNode.nextSibling;
 
           // 1.
-          var record = getRecord('childList', target);
+          var record = getRecord('childList', e.target.parentNode);
           record.addedNodes = addedNodes;
           record.removedNodes = removedNodes;
           record.previousSibling = previousSibling;
           record.nextSibling = nextSibling;
 
-          forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+          forEachAncestorAndObserverEnqueueRecord(e.relatedNode, function(options) {
             // 2.1, 3.2
             if (!options.childList)
               return;

--- a/tests/MutationObservers/childList.js
+++ b/tests/MutationObservers/childList.js
@@ -378,4 +378,25 @@ suite('JsMutationObserver childList', function() {
     });
   });
 
+  test('Append child in child', function() {
+    var div = testDiv.appendChild(document.createElement('div'));
+
+    var observer = new JsMutationObserver(function() {});
+    observer.observe(div, {
+      childList: true,
+      subtree: true
+    });
+    var div2 = document.createElement('div')
+    var div3 = div2.appendChild(document.createElement('div'));
+    div.appendChild(div2);
+    var records = observer.takeRecords();
+
+    if(records.length == 1) {
+      assert.strictEqual(records[0].target, div);
+      assert.strictEqual(records[0].addedNodes[0].firstChild, div3);
+    } else {
+      assert.strictEqual(records[0].target, div);
+      assert.strictEqual(records[1].target, div2);
+    }
+  });
 });

--- a/tests/MutationObservers/runner.html
+++ b/tests/MutationObservers/runner.html
@@ -17,6 +17,7 @@
 <script src="../tools/mocha-htmltest.js"></script>
 
 <!-- MutationObserver -->
+<script src="../../src/WeakMap/WeakMap.js"></script>
 <script src="../../src/MutationObserver/MutationObserver.js"></script>
 <script>
 


### PR DESCRIPTION
There is a difference in behavior between MutationObserver and this shim
in IE10, causing the target for a MutationRecord to be different from
the expect value.

This happens because when you append a node with children in IE10, it'll call the
DOMNodeInserted for the node and its children seperately.

The test has an if statement because the behavior is different between
IE10 and chrome, making both outcomes valid.

To test this PR you'll have to open the runner in IE10