### PR TITLE
Make HTMLImports polyfill more robust when assigning baseURI property

### DIFF
--- a/src/HTMLImports/importer.js
+++ b/src/HTMLImports/importer.js
@@ -129,7 +129,8 @@ function makeDocument(resource, url) {
   base.setAttribute('href', url);
   // add baseURI support to browsers (IE) that lack it.
   if (!doc.baseURI) {
-    doc.baseURI = url;
+    // Use defineProperty since Safari throws an exception when using assignment.
+    Object.defineProperty(doc, 'baseURI', {value:url});
   }
   // ensure UTF-8 charset
   var meta = doc.createElement('meta');


### PR DESCRIPTION
This came up within the context of Cordova apps (https://github.com/MobileChromeApps/mobile-chrome-apps/issues/450)

On iOS, doc.baseURI is null, and the assignment throws a `TypeError`:

```
TypeError: Attempted to assign to readonly property.
```

I actually don't see when it wouldn't be null since this is a new document. On Chrome, it doesn't throw, but the assignment also doesn't stick.

Instead of calling the setter, this PR creates a new property on the object itself.
