### PR TITLE
Fixes a wrong test for HTMLContentElement

### DIFF
--- a/tests/ShadowDOM/js/HTMLContentElement.js
+++ b/tests/ShadowDOM/js/HTMLContentElement.js
@@ -56,7 +56,8 @@ suite('HTMLContentElement', function() {
     df.appendChild(document.createTextNode(' '));
     root.appendChild(df);
 
-    assertArrayEqual(content.getDistributedNodes().length, 3);
+    assert.equal(content.getDistributedNodes().length, 7);
+    assertArrayEqual(content.getDistributedNodes(), host.childNodes);
   });
 
   test('getDistributedNodes add content deep inside tree', function() {


### PR DESCRIPTION
I found using `assertArrayEqual` to compare integers.
I guess, in this case, distributed nodes contain text nodes.
