### PR TITLE
Fix for a polymer mobile chrome app throwing 'TypeError: Attempted to as...

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -156,7 +156,7 @@ window.ShadowDOMPolyfill = {};
   function getSetter(name) {
     return hasEval && isIdentifierName(name) ?
         new Function('v', 'this.__impl4cf1e782hg__.' + name + ' = v') :
-        function(v) { this.__impl4cf1e782hg__[name] = v; };
+        function(v) { if( !(this instanceof Event) ) this.__impl4cf1e782hg__[name] = v; };
   }
 
   function getMethod(name) {


### PR DESCRIPTION
...sign to readonly property.' in iOS

See here for more info and screenshots: https://github.com/MobileChromeApps/mobile-chrome-apps/issues/457

After this fix I get no more errors and radio buttons work in iOS.
