### PR TITLE
fix(HTMLImports): HTMLImportsLoaded event dispatch throws error on IE

### DIFF
--- a/src/HTMLImports/base.js
+++ b/src/HTMLImports/base.js
@@ -214,8 +214,8 @@ if (useNative) {
 whenReady(function() {
   HTMLImports.ready = true;
   HTMLImports.readyTime = new Date().getTime();
-  var evt = rootDocument.createEvent('CustomEvent');
-  evt.initEvent("HTMLImportsLoaded", true, true);
+  var evt = rootDocument.createEvent("CustomEvent");
+  evt.initCustomEvent("HTMLImportsLoaded", true, true, {});
   rootDocument.dispatchEvent(evt);
 });
 


### PR DESCRIPTION
When using a  script loader such as require.js or system.js the HTMLImports polyfill will not load correctly on all versions of IE. It will throw a JavaScript error causing the program to crash. This is caused by the use of `CustomEvent` to dispatch the HTMLImportsLoaded event, which results in `Object doesn't support this function`. By explicitly using the older `createEvent` technique, the bug is fixed.
