### PR TITLE
element.matches() fixes

### DIFF
--- a/src/ShadowDOM/querySelector.js
+++ b/src/ShadowDOM/querySelector.js
@@ -49,7 +49,27 @@
   }
 
   function shimSelector(selector) {
-    return String(selector).replace(/\/deep\//g, ' ');
+    return String(selector)
+      // Transform `:host(selector)` to `selector`
+      .replace(
+        /:host\(([^\s]+)\)/g,
+        '$1'
+      )
+      // Transform `selector:host` to `selector`
+      .replace(
+        /([^\s]):host/g,
+        '$1'
+      )
+      // Transform `:host` to `*`
+      .replace(
+        ':host',
+        '*'
+      )
+      // From ShadowCSS, will be replaced by space
+      .replace(
+        /\^|\/shadow\/|\/shadow-deep\/|::shadow|\/deep\/|::content/g,
+        ' '
+      );
   }
 
   function findOne(node, selector) {
@@ -105,7 +125,7 @@
   }
 
   // find and findAll will only match Simple Selectors,
-  // Structural Pseudo Classes are not guarenteed to be correct
+  // Structural Pseudo Classes are not guaranteed to be correct
   // http://www.w3.org/TR/css3-selectors/#simple-selectors
 
   function querySelectorAllFiltered(p, index, result, selector, deep) {
@@ -181,6 +201,13 @@
           deep);
 
       return result;
+    }
+  };
+
+  var MatchesInterface = {
+    matches: function(selector) {
+      selector = shimSelector(selector);
+      return scope.originalMatches.call(unsafeUnwrap(this), selector);
     }
   };
 
@@ -272,5 +299,6 @@
 
   scope.GetElementsByInterface = GetElementsByInterface;
   scope.SelectorsInterface = SelectorsInterface;
+  scope.MatchesInterface = MatchesInterface;
 
 })(window.ShadowDOMPolyfill);

--- a/src/ShadowDOM/querySelector.js
+++ b/src/ShadowDOM/querySelector.js
@@ -49,6 +49,10 @@
   }
 
   function shimSelector(selector) {
+    return String(selector).replace(/\/deep\/|::shadow/g, ' ');
+  }
+
+  function shimMatchesSelector(selector) {
     return String(selector)
       // Transform `:host(selector)` to `selector`
       .replace(
@@ -206,7 +210,7 @@
 
   var MatchesInterface = {
     matches: function(selector) {
-      selector = shimSelector(selector);
+      selector = shimMatchesSelector(selector);
       return scope.originalMatches.call(unsafeUnwrap(this), selector);
     }
   };

--- a/src/ShadowDOM/wrappers/Element.js
+++ b/src/ShadowDOM/wrappers/Element.js
@@ -60,6 +60,30 @@
       oldValue: oldValue
     });
   }
+  function shimMatchesSelector (selector) {
+    selector = selector
+      // Transform `:host(selector)` to `selector`
+      .replace(
+        /:host\(([^\s]+)\)/g,
+        '$1'
+      )
+      // Transform `selector:host` to `selector`
+      .replace(
+        /([^\s]):host/g,
+        '$1'
+      )
+      // Transform `:host` to `*`
+      .replace(
+        ':host',
+        '*'
+      );
+    // From ShadowCSS, will be replaced by space
+    selector = selector.replace(
+      /\^|\/shadow\/|\/shadow-deep\/|::shadow|\/deep\/|::content/g,
+      ' '
+    );
+    return selector;
+  }
 
   var classListTable = new WeakMap();
 
@@ -99,6 +123,7 @@
     },
 
     matches: function(selector) {
+      selector = shimMatchesSelector(selector);
       return originalMatches.call(unsafeUnwrap(this), selector);
     },
 

--- a/src/ShadowDOM/wrappers/Element.js
+++ b/src/ShadowDOM/wrappers/Element.js
@@ -16,6 +16,7 @@
   var Node = scope.wrappers.Node;
   var ParentNodeInterface = scope.ParentNodeInterface;
   var SelectorsInterface = scope.SelectorsInterface;
+  var MatchesInterface = scope.MatchesInterface;
   var addWrapNodeListMethod = scope.addWrapNodeListMethod;
   var enqueueMutation = scope.enqueueMutation;
   var mixin = scope.mixin;
@@ -60,30 +61,6 @@
       oldValue: oldValue
     });
   }
-  function shimMatchesSelector (selector) {
-    selector = selector
-      // Transform `:host(selector)` to `selector`
-      .replace(
-        /:host\(([^\s]+)\)/g,
-        '$1'
-      )
-      // Transform `selector:host` to `selector`
-      .replace(
-        /([^\s]):host/g,
-        '$1'
-      )
-      // Transform `:host` to `*`
-      .replace(
-        ':host',
-        '*'
-      );
-    // From ShadowCSS, will be replaced by space
-    selector = selector.replace(
-      /\^|\/shadow\/|\/shadow-deep\/|::shadow|\/deep\/|::content/g,
-      ' '
-    );
-    return selector;
-  }
 
   var classListTable = new WeakMap();
 
@@ -120,11 +97,6 @@
       unsafeUnwrap(this).removeAttribute(name);
       enqueAttributeChange(this, name, oldValue);
       invalidateRendererBasedOnAttribute(this, name);
-    },
-
-    matches: function(selector) {
-      selector = shimMatchesSelector(selector);
-      return originalMatches.call(unsafeUnwrap(this), selector);
     },
 
     get classList() {
@@ -171,11 +143,13 @@
   mixin(Element.prototype, GetElementsByInterface);
   mixin(Element.prototype, ParentNodeInterface);
   mixin(Element.prototype, SelectorsInterface);
+  mixin(Element.prototype, MatchesInterface);
 
   registerWrapper(OriginalElement, Element,
                   document.createElementNS(null, 'x'));
 
   scope.invalidateRendererBasedOnAttribute = invalidateRendererBasedOnAttribute;
   scope.matchesNames = matchesNames;
+  scope.originalMatches = originalMatches;
   scope.wrappers.Element = Element;
 })(window.ShadowDOMPolyfill);

--- a/tests/ShadowDOM/js/Element.js
+++ b/tests/ShadowDOM/js/Element.js
@@ -125,6 +125,18 @@ suite('Element', function() {
     assert.equal(bb, list[0]);
   });
 
+  test('matches', function() {
+    var div = document.createElement('div');
+    div.classList.add('host-class');
+    document.body.appendChild(div);
+    var p = document.createElement('p');
+    p.classList.add('child-class');
+    div.appendChild(p);
+    assert.isTrue(p.matches(':host(.host-class) *'));
+    assert.isTrue(p.matches(':host::shadow .child-class'));
+    assert.isTrue(p.matches('.host-class /deep/ p.child-class'));
+  });
+
   skipTest('getElementsByTagName', function() {
     var div = document.createElement('div');
     div.innerHTML = '<a>0</a><a>1</a>';
@@ -388,17 +400,4 @@ suite('Element', function() {
     assert.instanceOf(abb, HTMLElement);
     assert.equal(abb, sbb);
   });
-
-  test('matches', function() {
-    var div = document.createElement('div');
-    div.classList.add('host-class');
-    document.body.appendChild(div);
-    var p = document.createElement('p');
-    p.classList.add('child-class');
-    div.appendChild(p);
-    assert.isTrue(p.matches(':host(.host-class) *'));
-    assert.isTrue(p.matches(':host::shadow .child-class'));
-    assert.isTrue(p.matches('.host-class /deep/ p.child-class'));
-  });
-
 });

--- a/tests/ShadowDOM/js/Element.js
+++ b/tests/ShadowDOM/js/Element.js
@@ -388,4 +388,17 @@ suite('Element', function() {
     assert.instanceOf(abb, HTMLElement);
     assert.equal(abb, sbb);
   });
+
+  test('matches', function() {
+    var div = document.createElement('div');
+    div.classList.add('host-class');
+    document.body.appendChild(div);
+    var p = document.createElement('p');
+    p.classList.add('child-class');
+    div.appendChild(p);
+    assert.isTrue(p.matches(':host(.host-class) *'));
+    assert.isTrue(p.matches(':host::shadow .child-class'));
+    assert.isTrue(p.matches('.host-class /deep/ p.child-class'));
+  });
+
 });

--- a/tests/ShadowDOM/js/Element.js
+++ b/tests/ShadowDOM/js/Element.js
@@ -103,6 +103,19 @@ suite('Element', function() {
     assert.equal(bb, div.querySelector('div /deep/ bb'));
   });
 
+  test('querySelector ::shadow', function() {
+    var div = document.createElement('div');
+    var div2 = document.createElement('div');
+    div.appendChild(div2);
+    var sr = div2.createShadowRoot();
+    sr.innerHTML = '<bb></bb>';
+    var bb = sr.firstChild;
+
+    div.offsetHeight;
+
+    assert.equal(bb, div.querySelector('div::shadow bb'));
+  });
+
   test('querySelectorAll deep', function() {
     var div = document.createElement('div');
     div.innerHTML = '<aa></aa><aa></aa>';
@@ -122,6 +135,21 @@ suite('Element', function() {
 
     list = div.querySelectorAll('div /deep/ bb');
     assert.equal(1, list.length);
+    assert.equal(bb, list[0]);
+  });
+
+  test('querySelectorAll ::shadow', function() {
+    var div = document.createElement('div');
+    var div2 = document.createElement('div');
+    div.appendChild(div2);
+    var sr = div2.createShadowRoot();
+    sr.innerHTML = '<bb></bb><bb></bb>';
+    var bb = sr.firstChild;
+
+    div.offsetHeight;
+
+    var list = div.querySelectorAll('div::shadow bb');
+    assert.equal(2, list.length);
     assert.equal(bb, list[0]);
   });
 


### PR DESCRIPTION
Support for `:host`, `::content` and similar selectors in `element.matches()` 