### PR TITLE
Point package.json to the actual main script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webcomponents.js",
   "version": "0.5.4",
   "description": "webcomponents.js",
-  "main": "gulpfile.js",
+  "main": "webcomponents.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
If you point the `main` in the `package.json` to the `webcomponents.js` script, I can require it using browserify or webpack with:

```js
require('webcomponents.js')
```

As oppose to currently needing to do:

```js
require('webcomponents.js/webcomponents.js')
```

Thanks!