### PR TITLE
install createShadowRoot only if present, fixes #174

### DIFF
--- a/src/CustomElements/observe.js
+++ b/src/CustomElements/observe.js
@@ -289,13 +289,17 @@ function upgradeDocumentTree(doc) {
 }
 
 
-// ensure that all ShadowRoots watch for CustomElements.
+// Patch `createShadowRoot()` if Shadow DOM is available, otherwise leave
+// undefined to aid feature detection of Shadow DOM.
 var originalCreateShadowRoot = Element.prototype.createShadowRoot;
-Element.prototype.createShadowRoot = function() {
-  var root = originalCreateShadowRoot.call(this);
-  CustomElements.watchShadow(this);
-  return root;
-};
+if (originalCreateShadowRoot) {
+  // ensure that all ShadowRoots watch for CustomElements.
+  Element.prototype.createShadowRoot = function() {
+    var root = originalCreateShadowRoot.call(this);
+    CustomElements.watchShadow(this);
+    return root;
+  };
+}
 
 // exports
 scope.watchShadow = watchShadow;


### PR DESCRIPTION
Pretty simple fix. Since ShadowDOM polyfill must always be loaded first, this should work in both webcomponents-lite.js and webcomponents.js mode