### PR TITLE
Make broken descriptors configurable on Safari

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -226,10 +226,13 @@ window.ShadowDOMPolyfill = {};
           setter = getSetter(name);
       }
 
+      // make all descriptors configurable on broken safari
+      var configurable = isBrokenSafari || descriptor.configurable;
+
       defineProperty(target, name, {
         get: getter,
         set: setter,
-        configurable: descriptor.configurable,
+        configurable: configurable,
         enumerable: descriptor.enumerable
       });
     }

--- a/src/ShadowDOM/wrappers/SVGElement.js
+++ b/src/ShadowDOM/wrappers/SVGElement.js
@@ -14,6 +14,7 @@
   var Element = scope.wrappers.Element;
   var HTMLElement = scope.wrappers.HTMLElement;
   var registerObject = scope.registerObject;
+  var defineWrapGetter = scope.defineWrapGetter;
 
   var SVG_NS = 'http://www.w3.org/2000/svg';
   var svgTitleElement = document.createElementNS(SVG_NS, 'title');
@@ -29,6 +30,8 @@
     Object.defineProperty(HTMLElement.prototype, 'classList', descr);
     delete Element.prototype.classList;
   }
+
+  defineWrapGetter(SVGElement, 'ownerSVGElement');
 
   scope.wrappers.SVGElement = SVGElement;
 })(window.ShadowDOMPolyfill);

--- a/tests/ShadowDOM/js/SVGElement.js
+++ b/tests/ShadowDOM/js/SVGElement.js
@@ -72,4 +72,16 @@ suite('SVGElement', function() {
     }
   });
 
+  test('ownerSVGElement', function() {
+    var el = document.createElementNS(SVG_NS, 'svg');
+    var el2 = document.createElementNS(SVG_NS,'svg');
+    var g = document.createElementNS(SVG_NS, 'g');
+    el.appendChild(g);
+
+    assert.equal(g.ownerSVGElement, el);
+
+    el2.appendChild(g);
+
+    assert.equal(g.ownerSVGElement, el2);
+  });
 });


### PR DESCRIPTION
Allows after-registration usage of getter/setter additions.
Fixes #159