### PR TITLE
Drop Mutation Observer polyfills for elements, imports

### DIFF
--- a/src/CustomElements/CustomElements.js
+++ b/src/CustomElements/CustomElements.js
@@ -28,7 +28,6 @@ var file = 'CustomElements.js';
 
 var modules = [
   '../WeakMap/WeakMap.js',
-  '../MutationObserver/MutationObserver.js',
   'base.js',
   'traverse.js',
   'observe.js',

--- a/src/CustomElements/build.json
+++ b/src/CustomElements/build.json
@@ -1,6 +1,5 @@
 [
   "../WeakMap/WeakMap.js",
-  "../MutationObserver/MutationObserver.js",
   "base.js",
   "traverse.js",
   "observe.js",

--- a/src/HTMLImports/HTMLImports.js
+++ b/src/HTMLImports/HTMLImports.js
@@ -27,7 +27,6 @@ var file = 'HTMLImports.js';
 
 var modules = [
   '../WeakMap/WeakMap.js',
-  '../MutationObserver/MutationObserver.js',
   'base.js',
   'module.js',
   'path.js',

--- a/src/HTMLImports/build.json
+++ b/src/HTMLImports/build.json
@@ -1,6 +1,5 @@
 [
   "../WeakMap/WeakMap.js",
-  "../MutationObserver/MutationObserver.js",
   "base.js",
   "module.js",
   "path.js",

--- a/src/WebComponents/build-lite.json
+++ b/src/WebComponents/build-lite.json
@@ -1,8 +1,8 @@
 [
   "build/boot.js",
+  "../MutationObserver/MutationObserver.js"
   "../HTMLImports/build.json",
   "../CustomElements/build.json",
   "../Template/Template.js",
-  "../MutationObserver/MutationObserver.js"
   "unresolved.js"
 ]

--- a/src/WebComponents/build-lite.json
+++ b/src/WebComponents/build-lite.json
@@ -3,5 +3,6 @@
   "../HTMLImports/build.json",
   "../CustomElements/build.json",
   "../Template/Template.js",
+  "../MutationObserver/MutationObserver.js"
   "unresolved.js"
 ]


### PR DESCRIPTION
Fixes to drop MutationObservers from being pulled in for CustomElements and HTMLImports polyfills. 
This set of patches will also add MOs to the build-lite.json, per a request from John in my original PR: 
https://github.com/webcomponents/webcomponentsjs/pull/34

reviewer(s): @jmesserly @garlicnation 
