### PR TITLE
Include URL polyfill references in lite/full builds

### DIFF
--- a/src/WebComponents/build-lite.json
+++ b/src/WebComponents/build-lite.json
@@ -1,5 +1,6 @@
 [
   "build/boot.js",
+  "../URL/URL.js",
   "../HTMLImports/build.json",
   "../CustomElements/build.json",
   "../Template/Template.js",

--- a/src/WebComponents/build.json
+++ b/src/WebComponents/build.json
@@ -5,6 +5,7 @@
   "../ShadowCSS/ShadowCSS.js",
   "build/end-if.js",
   "shadowdom.js",
+  "../URL/URL.js",
   "../HTMLImports/build.json",
   "../CustomElements/build.json",
   "lang.js",


### PR DESCRIPTION
(Please don't merge until #196 lands)

Continuing changes for #135, this change specifies the URL polyfill as a build-time dependency before HTML Imports. Given that the use-case for us landing URL polyfill support was Imports, I believe this is the right place.

Feel free to let me know if not. 