### PR TITLE
Add browser support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Pre-built (concatenated & minified) versions of the polyfills are maintained in 
 `webcomponents-lite.js` includes all polyfills except for shadow DOM.
 
 
+## Browser Support
+
+Our polyfills are intended to work in the latest versions of evergreen browsers. See below
+for our complete browser support matrix:
+
+|   | IE10 | IE11+ | Chrome* | Firefox* | Safari 7+* | Chrome Android* | Mobile Safari* |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| __Custom Elements__ | ~ | x | x | x | x | x| x
+| __HTML Imports__ | ~ | x | x | x | x| x| x
+| __Shadow DOM__ | x | x | x | x | x | x | x
+| __Templates__ | x | x | x | x| x | x | x
+
+*Indicates the current version of the browser
+~Indicates support may be flaky
+
+
 ### Manually Building
 
 If you wish to build the polyfills yourself, you'll need `node` and `gulp` on your system:

--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ for our complete browser support matrix:
 
 |   | IE10 | IE11+ | Chrome* | Firefox* | Safari 7+* | Chrome Android* | Mobile Safari* |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| __Custom Elements__ | ~ | x | x | x | x | x| x
-| __HTML Imports__ | ~ | x | x | x | x| x| x
-| __Shadow DOM__ | x | x | x | x | x | x | x
-| __Templates__ | x | x | x | x| x | x | x
+| __Custom Elements__ | ~ | ✓ | ✓ | ✓ | ✓ | ✓| ✓
+| __HTML Imports__ | ~ | ✓ | ✓ | ✓ | ✓| ✓| ✓
+| __Shadow DOM__ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓
+| __Templates__ | ✓ | ✓ | ✓ | ✓| ✓ | ✓ | ✓
+
 
 *Indicates the current version of the browser
-~Indicates support may be flaky
+
+~Indicates support may be flaky. If using Custom Elements or HTML Imports with Shadow DOM,
+you will get the non-flaky Mutation Observer polyfill that Shadow DOM includes.
+
+The polyfills may work in older browsers, however require additional polyfills (such as classList)
+to be used. We cannot guarantee support for browsers outside of our compatibility matrix.
 
 
 ### Manually Building


### PR DESCRIPTION
Fixes #65. We've discussed adding a revised browser support matrix to the project for a while. Consider this a first attempt at defining that.

Renders:

![screen shot 2015-02-12 at 17 23 16](https://cloud.githubusercontent.com/assets/110953/6173372/631d0778-b2df-11e4-9cb8-f83507b08a11.png)

Some considerations:

* I've attempted to be consistent with our old matrix in saying IE10 support for CE + Imports are flaky due to mutation observers. Is our position here still the same?
* We've intentionally not noted support for IE9 in the past. Developers are however attempting this - do we want to add a note in the README calling out these efforts?
* Should Safari (desktop) join the other vendors in being latest version only, or is 7+ sufficient?