### PR TITLE
Passes detailed import load\error info to callback

### DIFF
--- a/tests/HTMLImports/html/dynamic-all-imports-detail.html
+++ b/tests/HTMLImports/html/dynamic-all-imports-detail.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>HTML Imports Dynamic</title>
+    <script src="../../tools/htmltest.js"></script>
+    <script src="../../tools/chai/chai.js"></script>
+    <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+  </head>
+  <body>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        // some time later
+        setTimeout(function() {
+          var div = document.createElement('div');
+          div.innerHTML = '<link rel="import" href="imports/load-1.html">' +
+              '<link rel="import" href="imports/load-2.html">';
+          document.body.appendChild(div);
+          var ports = document.querySelectorAll('link[rel=import]');
+          var loads = 0;
+          for (var i=0, l=ports.length, n; (i<l) && (n=ports[i]); i++) {
+            n.addEventListener('load', function(e) {
+              loads++;
+              chai.assert.ok(e.target.import);
+            });
+          }
+          HTMLImports.whenReady(function(detail) {
+            chai.assert.equal(detail.allImports.length, 2);
+            chai.assert.equal(detail.loadedImports.length, 2);
+
+            chai.expect(detail.allImports[0].href).to.contain('imports/load-1.html');
+            chai.expect(detail.allImports[1].href).to.contain('imports/load-2.html');
+
+            done();
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/HTMLImports/html/dynamic-errors-detail.html
+++ b/tests/HTMLImports/html/dynamic-errors-detail.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>HTML Imports Dynamic</title>
+    <script src="../../tools/htmltest.js"></script>
+    <script src="../../tools/chai/chai.js"></script>
+    <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+  </head>
+  <body>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        // some time later
+        setTimeout(function() {
+          var div = document.createElement('div');
+          div.innerHTML = '<link rel="import" href="imports/load-1.html">' +
+              '<link rel="import" href="imports/load-does-not-exist.html">';
+          document.body.appendChild(div);
+          var ports = document.querySelectorAll('link[rel=import]');
+          var loads = 0;
+          for (var i=0, l=ports.length, n; (i<l) && (n=ports[i]); i++) {
+            n.addEventListener('load', function(e) {
+              loads++;
+              chai.assert.ok(e.target.import);
+            });
+          }
+          HTMLImports.whenReady(function(detail) {
+            chai.assert.equal(detail.allImports.length, 2);
+            chai.assert.equal(detail.errorImports.length, 1);
+            chai.assert.equal(detail.loadedImports.length, 1);
+
+            var errorImport = detail.errorImports[0];
+            chai.expect(errorImport.href).to.contain('imports/load-does-not-exist.html');
+
+            done();
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/HTMLImports/html/dynamic-loaded-detail.html
+++ b/tests/HTMLImports/html/dynamic-loaded-detail.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>HTML Imports Dynamic</title>
+    <script src="../../tools/htmltest.js"></script>
+    <script src="../../tools/chai/chai.js"></script>
+    <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+  </head>
+  <body>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        // some time later
+        setTimeout(function() {
+          var div = document.createElement('div');
+          div.innerHTML = '<link rel="import" href="imports/load-1.html">' +
+              '<link rel="import" href="imports/load-2.html">';
+          document.body.appendChild(div);
+          var ports = document.querySelectorAll('link[rel=import]');
+          var loads = 0;
+          for (var i=0, l=ports.length, n; (i<l) && (n=ports[i]); i++) {
+            n.addEventListener('load', function(e) {
+              loads++;
+              chai.assert.ok(e.target.import);
+            });
+          }
+          HTMLImports.whenReady(function(detail) {
+            chai.assert.equal(detail.allImports.length, 2);
+            chai.assert.equal(detail.errorImports.length, 0);
+            chai.assert.equal(detail.loadedImports.length, 2);
+
+            chai.expect(detail.loadedImports[0].href).to.contain('imports/load-1.html');
+            chai.expect(detail.loadedImports[1].href).to.contain('imports/load-2.html');
+
+            done();
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/HTMLImports/tests.js
+++ b/tests/HTMLImports/tests.js
@@ -21,6 +21,9 @@ htmlSuite('HTMLImports', function() {
   htmlTest('html/currentScript.html');
   htmlTest('html/dedupe.html');
   htmlTest('html/dynamic.html');
+  htmlTest('html/dynamic-all-imports-detail.html');
+  htmlTest('html/dynamic-errors-detail.html');
+  htmlTest('html/dynamic-loaded-detail.html');
   htmlTest('html/csp.html');
   htmlTest('html/customevent-detail.html');
   htmlTest('html/encoding.html');


### PR DESCRIPTION
fixes [polymer/#1184](http://github.com/polymer/polymer/issues/1184)
fixes [polymer/#1127](http://github.com/polymer/polymer/issues/1127)

Example usage:
```js
Polymer.import(["http://url1", "http://url2", "http://etc.."], function(detail) {
  var hasAllImports = detail.allImports.length > 0;
  var hasLoadedImports = detail.loadedImports.length > 0;
  var hasErrorImports = detail.errorImports.length > 0;
}
```