### PR TITLE
Fixed issue #219 related to polymer import callback getting called

### DIFF
--- a/src/HTMLImports/base.js
+++ b/src/HTMLImports/base.js
@@ -118,11 +118,14 @@ function watchImportsLoad(callback, doc) {
   var parsedCount = 0, importCount = imports.length, newImports = [], errorImports = [];
   function checkDone() {
     if (parsedCount == importCount && callback) {
-      callback({
-        allImports: imports,
-        loadedImports: newImports,
-        errorImports: errorImports
-      });
+	
+		if(errorImports.length == 0) {
+			callback({
+			allImports: imports,
+			loadedImports: newImports,
+			errorImports: errorImports
+		  });
+		}      
     }
   }
   function loadedImport(e) {


### PR DESCRIPTION
Fix for #219 ( #220 ) : added the condition in checkDone() function to check if there is an error encountered in loading the import. If so, then I am preventing the callback() from getting called. The function call of callback()  in checkDone() is internally triggering the whenReady function in polymer.js which in turn calls the web components' callback(mentioned in Polymer.import) while flushing the ready queue.