### PR TITLE
Add URL toString() method

### DIFF
--- a/src/URL/URL.js
+++ b/src/URL/URL.js
@@ -467,6 +467,9 @@
   }
 
   jURL.prototype = {
+    toString: function() {
+      return this.href;
+    },
     get href() {
       if (this._isInvalid)
         return this._url;


### PR DESCRIPTION
Add URL toString() method to return synonym for href. (according to spec)

Current build:

    var u = new URL('b', 'http://a');
    console.log( u.toString() ); // "[object Object]""

After patch:

    var u = new URL('b', 'http://a');
    console.log( u.toString() ); // "http://a/b"

// currently I cannot find URL related test on tests folder, should I write some tests for this patch?