### PR TITLE
Move WeakMap polyfill to the beginning. 

### DIFF
--- a/src/WebComponents/build-lite.json
+++ b/src/WebComponents/build-lite.json
@@ -1,5 +1,6 @@
 [
   "build/boot.js",
+  "../WeakMap/WeakMap.js",
   "../URL/URL.js",
   "../MutationObserver/MutationObserver.js",
   "../HTMLImports/build.json",

--- a/src/WebComponents/build.json
+++ b/src/WebComponents/build.json
@@ -1,5 +1,6 @@
 [
   "build/boot.js",
+  "../WeakMap/WeakMap.js",
   "build/if-poly.js",
   "../ShadowDOM/build.json",
   "../ShadowCSS/ShadowCSS.js",


### PR DESCRIPTION
Pull WeakMap polyfill to the file beginning. The reason as below:

**webcomponents-lite.js**

In current build, WeakMap is polyfill after than MutationObserver.
But MutationObserver is depend on WeakMap.

So if browser does not support WeakMap (like safari 7, or some China browsers based on older version chrome),
it will cause some exception. And if swap WeakMap and MutationObserver, the code works good.

**webcomponents.js**

In webcomponents.js build, WeakMap polyfill is inside a shadow dom statement like below:

    if (WebComponents.flags.shadow) {
      if (typeof WeakMap === "undefined") {
          // code is here
      }
    }

I think WeakMap polyfill and ShadowDom polyfill is independent module,
So I update the build.json to move WeakMap outside ShadowDom polyfill.

---
Th PR is related to #234. 