### PR TITLE
Fixes #168 - refer to correct file for-lite builds

### DIFF
--- a/src/WebComponents/build-lite.json
+++ b/src/WebComponents/build-lite.json
@@ -1,5 +1,5 @@
 [
-  "build/boot.js",
+  "build/boot-lite.js",
   "../URL/URL.js",
   "../MutationObserver/MutationObserver.js",
   "../HTMLImports/build.json",

--- a/src/WebComponents/build/boot-lite.js
+++ b/src/WebComponents/build/boot-lite.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+window.WebComponents = window.WebComponents || {};
+
+// process flags
+(function(scope){
+  
+  // import
+  var flags = scope.flags || {};
+  
+  var file = 'webcomponents-lite.js';
+  var script = document.querySelector('script[src*="' + file + '"]');
+
+  // Flags. Convert url arguments to flags
+  if (!flags.noOpts) {
+    // from url
+    location.search.slice(1).split('&').forEach(function(o) {
+      o = o.split('=');
+      o[0] && (flags[o[0]] = o[1] || true);
+    });
+    // from script
+    if (script) {
+      for (var i=0, a; (a=script.attributes[i]); i++) {
+        if (a.name !== 'src') {
+          flags[a.name] = a.value || true;
+        }
+      }
+    }
+    // log flags
+    if (flags.log) {
+      var parts = flags.log.split(',');
+      flags.log = {};
+      parts.forEach(function(f) {
+        flags.log[f] = true;
+      });
+    } else {
+      flags.log = {};
+    }
+  }
+
+  // Determine default settings.
+  // If any of these flags match 'native', then force native ShadowDOM; any
+  // other truthy value, or failure to detect native
+  // ShadowDOM, results in polyfill 
+  flags.shadow = (flags.shadow || flags.shadowdom || flags.polyfill);
+  if (flags.shadow === 'native') {
+    flags.shadow = false;
+  } else {
+    flags.shadow = flags.shadow || !HTMLElement.prototype.createShadowRoot;
+  }
+
+  // forward flags
+  if (flags.register) {
+    window.CustomElements = window.CustomElements || {flags: {}};
+    window.CustomElements.flags.register = flags.register;
+  }
+
+  // export
+  scope.flags = flags;
+})(WebComponents);


### PR DESCRIPTION
This is a quick and dirty solution for #168. 

An alternative would be to use feature flags to determine whether someone is trying to build a custom elements + imports build (and just call the file -lite then). @garlicnation PTAL.