### PR TITLE
fix #256 -- DOM objects with numeric properties

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -150,7 +150,7 @@ window.ShadowDOMPolyfill = {};
   }
 
   function isIdentifierName(name) {
-    return /^\w[a-zA-Z_0-9]*$/.test(name);
+    return /^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test(name);
   }
 
   // The name of the implementation property is intentionally hard to
@@ -426,6 +426,7 @@ window.ShadowDOMPolyfill = {};
   scope.defineGetter = defineGetter;
   scope.defineWrapGetter = defineWrapGetter;
   scope.forwardMethodsToWrapper = forwardMethodsToWrapper;
+  scope.isIdentifierName = isIdentifierName;
   scope.isWrapper = isWrapper;
   scope.isWrapperFor = isWrapperFor;
   scope.mixin = mixin;

--- a/tests/ShadowDOM/js/wrappers.js
+++ b/tests/ShadowDOM/js/wrappers.js
@@ -114,4 +114,29 @@ suite('Wrapper creation', function() {
     });
   });
 
+  test('isIdentifierName', function() {
+    var isIdentifierName = ShadowDOMPolyfill.isIdentifierName;
+    // Not identiifers:
+    assert.isFalse(isIdentifierName('123'));
+    assert.isFalse(isIdentifierName('%123'));
+    assert.isFalse(isIdentifierName('-123'));
+
+    // Identifiers:
+    assert.isTrue(isIdentifierName('_123'));
+    assert.isTrue(isIdentifierName('$123'));
+    assert.isTrue(isIdentifierName('abC'));
+    assert.isTrue(isIdentifierName('abc$123'));
+  });
+
+  test('Integer property names', function() {
+    // Create a fake "native" DOM object to test wrapping a numeric property.
+    function TestNative() {}
+    TestNative.prototype['123'] = function() { return 42; };
+    function TestWrapper() {
+      ShadowDOMPolyfill.setWrapper(new TestNative(), this);
+    }
+    ShadowDOMPolyfill.registerWrapper(TestNative, TestWrapper);
+    var wrapper = new TestWrapper();
+    assert.equal(wrapper['123'](), 42);
+  });
 });


### PR DESCRIPTION
This fixes #256, an error caused by trying to wrap an integer property on a native DOM object. Apparently some embedded MS Office objects run on IE9 and have this behavior. The `\w` in the regexp was wrong because it matches digits. Also adds `$` because that is legal in JS identifiers.

Adds two tests: a unit test for isIdentifierName, and a test for wrapping an integer property. Both of them fail before the fix and pass after.