### PR TITLE
Handle XHTML self-closing void tag behavior

### DIFF
--- a/src/ShadowDOM/wrappers/Document.js
+++ b/src/ShadowDOM/wrappers/Document.js
@@ -332,6 +332,12 @@
     setWrapper(impl, this);
   }
 
+  var originalCreateDocument = document.implementation.createDocument;
+  DOMImplementation.prototype.createDocument = function() {
+    arguments[2] = unwrap(arguments[2]);
+    return wrap(originalCreateDocument.apply(unsafeUnwrap(this), arguments));
+  };
+
   function wrapImplMethod(constructor, name) {
     var original = document.implementation[name];
     constructor.prototype[name] = function() {
@@ -347,7 +353,6 @@
   }
 
   wrapImplMethod(DOMImplementation, 'createDocumentType');
-  wrapImplMethod(DOMImplementation, 'createDocument');
   wrapImplMethod(DOMImplementation, 'createHTMLDocument');
   forwardImplMethod(DOMImplementation, 'hasFeature');
 
@@ -356,8 +361,8 @@
   forwardMethodsToWrapper([
     window.DOMImplementation,
   ], [
-    'createDocumentType',
     'createDocument',
+    'createDocumentType',
     'createHTMLDocument',
     'hasFeature',
   ]);

--- a/tests/ShadowDOM/js/Document.js
+++ b/tests/ShadowDOM/js/Document.js
@@ -33,6 +33,13 @@ htmlSuite('Document', function() {
     assert.equal(doc2.lastElementChild.tagName, 'HTML');
   });
 
+  test('Create XHTML Document', function() {
+    var docType = wrap(document).implementation.createDocumentType('html', '-//W3C//DTD XHTML 1.0 Transitional//EN',
+                            'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd');
+    var doc = wrap(document).implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', docType);
+    assert(doc);
+  });
+
   test('document.documentElement', function() {
     var doc = wrap(document);
     assert.equal(doc.documentElement.ownerDocument, doc);

--- a/tests/ShadowDOM/js/HTMLElement.js
+++ b/tests/ShadowDOM/js/HTMLElement.js
@@ -114,4 +114,12 @@ suite('HTMLElement', function() {
     div.hidden = false;
     assert.isFalse(div.hasAttribute('hidden'));
   });
+
+  test('img outerHTML in XHTML documents', function() {
+    var docType = document.implementation.createDocumentType('html', '-//W3C//DTD XHTML 1.0 Transitional//EN',
+                            'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd');
+    var doc = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', docType);
+    var img = doc.createElement('img');
+    assert.equal(img.outerHTML, '<img/>');
+  });
 });


### PR DESCRIPTION
Also wrap createDocument correctly for handling doctypes.

Fixes #278 ShadowDOM.js causing unclosed img tags in XHTML