### PR TITLE
Prevent register() from throwing exceptions when nativeConstructor is undefined

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -256,6 +256,9 @@ window.ShadowDOMPolyfill = {};
    *     properties from an instance object.
    */
   function register(nativeConstructor, wrapperConstructor, opt_instance) {
+    if (nativeConstructor == null) {
+      return;
+    }
     var nativePrototype = nativeConstructor.prototype;
     registerInternal(nativePrototype, wrapperConstructor, opt_instance);
     mixinStatics(wrapperConstructor, nativeConstructor);


### PR DESCRIPTION
In certain instances, register may be called with an undefined nativeConstructor thus throwing an exception when .prototype is not defined. If the native object does not exist, wrapping it makes no sense so we should just proceed rather than break all subsequent element registration.