### PR TITLE
Fixes #317 - Ensure super class methods are added to GeneratedWrapper base classes as methods instead of a value with get/set

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -219,9 +219,11 @@ window.ShadowDOMPolyfill = {};
       }
       var descriptor = getDescriptor(source, name);
       var getter, setter;
-      if (allowMethod && typeof descriptor.value === 'function') {
-        target[name] = getMethod(name);
-        continue;
+      if(typeof descriptor.value === 'function') {
+          if (allowMethod) {
+              target[name] = getMethod(name);
+          }
+          continue;
       }
 
       var isEvent = isEventHandlerName(name);

--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -101,7 +101,7 @@ window.ShadowDOMPolyfill = {};
   // Make sure they are create before we start modifying things.
   getOwnPropertyNames(window);
 
-  function getWrapperConstructor(node) {
+  function getWrapperConstructor(node, opt_instance) {
     var nativePrototype = node.__proto__ || Object.getPrototypeOf(node);
     if (isFirefox) {
       // HTMLEmbedElements will sometimes be [NS Object wrapper class]
@@ -121,7 +121,7 @@ window.ShadowDOMPolyfill = {};
     var parentWrapperConstructor = getWrapperConstructor(nativePrototype);
 
     var GeneratedWrapper = createWrapperConstructor(parentWrapperConstructor);
-    registerInternal(nativePrototype, GeneratedWrapper, node);
+    registerInternal(nativePrototype, GeneratedWrapper, opt_instance);
 
     return GeneratedWrapper;
   }
@@ -334,8 +334,13 @@ window.ShadowDOMPolyfill = {};
       return null;
 
     assert(isNative(impl));
-    return impl.__wrapper8e3dd93a60__ ||
-        (impl.__wrapper8e3dd93a60__ = new (getWrapperConstructor(impl))(impl));
+    var wrapper = impl.__wrapper8e3dd93a60__;
+    if (wrapper != null) {
+      return wrapper;
+    }
+
+    return impl.__wrapper8e3dd93a60__ =
+      new (getWrapperConstructor(impl, impl))(impl);
   }
 
   /**

--- a/tests/ShadowDOM/js/wrappers.js
+++ b/tests/ShadowDOM/js/wrappers.js
@@ -94,6 +94,23 @@ suite('Wrapper creation', function() {
     assert.isTrue(Object.getPrototypeOf(br).hasOwnProperty('clear'));
   });
 
+  // Super class is defined as a class above the existing wrapped class (GeneratedWrapper).
+  test('Super class methods are wrapped as methods on base class', function() {
+      // Set a method on a prototype whose parent prototype is not yet wrapped
+      SVGTextElement.prototype.customFn = function(arg) { return arg; };
+      var textNode = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      var wrappedPrototype = Object.getPrototypeOf(textNode);
+      var customFnDescriptor = Object.getOwnPropertyDescriptor(wrappedPrototype, 'customFn');
+      // TODO: This assertion might qualify as a separate test? Not sure if
+      // accessing prototype via Object.getPrototypeOf(Object.getPrototypeOf(textNode))
+      // is by design.
+      assert.isDefined(customFnDescriptor, 'Prototype method should be on first prototype of instance');
+      assert.isFunction(customFnDescriptor.value, 'Super method should be a function');
+      assert.isUndefined(customFnDescriptor.get, 'Super method should not be get/set');
+      assert.isUndefined(customFnDescriptor.set);
+      delete SVGTextElement.prototype.customFn;
+  });
+
   test('HTMLUnknownElement constructor', function() {
     var element = document.createElement('unknownelement');
     assert.instanceOf(element, HTMLUnknownElement);


### PR DESCRIPTION
Fixes issue #317 where IE couldn't call getBBox on SVGTextElement nodes.  The issue can be described as follows:

C extends B extends A, where A is the base class and C has new methods not in B or A.  We create a node C.  During registerInstanceProperties onto wrapped B, C's methods get added onto wrapped B as get/set.  Later in addForwardingProperties onto wrapped B, C's methods aren't added onto wrapped B because they've already been added incorrectly as get/set.

This occurs in IE because SVGTextElement.prototype defines getBBox and is separated from the "base" GeneratedWrapper (SVGElement) by some classes (SVGTextPositioningElement, SVGTextContentElement).  I think this issue would apply to other nodes that have similar inheritance/new method conditions described above (C, B, A).

The tests seem to be passing with the same numbers in Windows 7 IE 11, OS X Chrome/Firefox; I'm not sure what form of unit test would be good for this. Perhaps create 2 custom elements to recreate the C, B, A scenario.