### PR TITLE
Remove `Edge` from sniff in src/HTMLImports/base.js.

### DIFF
--- a/src/HTMLImports/base.js
+++ b/src/HTMLImports/base.js
@@ -70,7 +70,7 @@ Object.defineProperty(rootDocument, '_currentScript', currentScriptDescriptor);
   the polyfill and native implementation.
  */
 
-var isIE = /Trident|Edge/.test(navigator.userAgent);
+var isIE = /Trident/.test(navigator.userAgent);
 
 // call a callback when all HTMLImports in the document at call time
 // (or at least document ready) have loaded.


### PR DESCRIPTION
I've noticed [some sites](http://www.google.com/design/icons/) using webcomponents.js are failing to load in MS Edge. I've found switching the UA string off MS Edge to something else makes it work. It looks like it's related to the sniff in src/HTMLImports/base.js.