### PR TITLE
Remove `<link>` tag from install polymer warning

### DIFF
--- a/src/WebComponents/dom.js
+++ b/src/WebComponents/dom.js
@@ -80,8 +80,7 @@
     if (window.Polymer === polymerStub) {
       window.Polymer = function() {
         throw new Error('You tried to use polymer without loading it first. To ' +
-          'load polymer, <link rel="import" href="' +
-          'components/polymer/polymer.html">');
+          'load polymer, import polymer.html.');
       };
     }
   }


### PR DESCRIPTION
The polymer warning appears to be causing a GET `components/polymer/polymer.html` request (despite polymer already being on the page). For starters, the request itself is surprising. Worse, I don't have a `components` directory in my application so this request will always fail.

I'm not sure what's causing the error text to be evaluated this way, but removing it stops my application from making the mistaken request.
