### PR TITLE
Suppress runtime error if you load twice webcomponents-lite.js

### DIFF
--- a/src/WebComponents/build/boot-lite.js
+++ b/src/WebComponents/build/boot-lite.js
@@ -37,7 +37,7 @@ window.WebComponents = window.WebComponents || {};
       }
     }
     // log flags
-    if (flags.log) {
+    if (flags.log && flags.log.split) {
       var parts = flags.log.split(',');
       flags.log = {};
       parts.forEach(function(f) {


### PR DESCRIPTION
If you load webcomponents-lite.js twice you get an TypeError with 'flags.log.split is not a function'
