### PR TITLE
Fix issue #342: check whether a script's parent exists before removing script from that parent

### DIFF
--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -229,7 +229,9 @@ var importParser = {
     // keep track of executing script to help polyfill `document.currentScript`
     scope.currentScript = scriptElt;
     this.trackElement(script, function(e) {
-      script.parentNode.removeChild(script);
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
       scope.currentScript = null;
     });
     this.addElementToDocument(script);


### PR DESCRIPTION
It's still unclear why this condition can arise. Nevertheless, if the condition does arise, and the script has no parent, then presumably it's no longer important to remove the script from its parent.