### PR TITLE
Fixes #351

### DIFF
--- a/src/CustomElements/upgrade.js
+++ b/src/CustomElements/upgrade.js
@@ -35,11 +35,15 @@ var flags = scope.flags;
 function upgrade(node, isAttached) {
   if (!node.__upgraded__ && (node.nodeType === Node.ELEMENT_NODE)) {
     var is = node.getAttribute('is');
-    var definition = scope.getRegisteredDefinition(is || node.localName);
+    // find definition first by localName and secondarily by is attribute
+    var definition = scope.getRegisteredDefinition(node.localName) ||
+      scope.getRegisteredDefinition(is);
     if (definition) {
-      if (is && definition.tag == node.localName) {
-        return upgradeWithDefinition(node, definition, isAttached);
-      } else if (!is && !definition.extends) {
+      // upgrade with is iff the definition tag matches the element tag
+      // and don't upgrade if there's an is and the definition does not extend
+      // a native element
+      if ((is && definition.tag == node.localName) ||
+        (!is && !definition.extends)) {
         return upgradeWithDefinition(node, definition, isAttached);
       }
     }

--- a/tests/CustomElements/js/upgrade.js
+++ b/tests/CustomElements/js/upgrade.js
@@ -118,4 +118,16 @@ suite('upgradeElements', function() {
     });
   });
 
+  test('CustomElements.upgrade upgrades element syntax and ignores bogus type extension', function() {
+    var XProto = Object.create(HTMLElement.prototype);
+    XProto.test = 'x-test-value';
+    document.registerElement('x-test', {
+      prototype: XProto
+    });
+    work.innerHTML = '<x-test is="x-foo"></x-test>';
+    CustomElements.upgradeAll(work);
+    var x = work.querySelector('x-test');
+    assert.equal(x.test, 'x-test-value');
+  });
+
 });


### PR DESCRIPTION
Fixes #351: : an element upgrades first via its tag name and only secondarily by its is attribute.