### PR TITLE
Don't fake a load event for styles on Edge

### DIFF
--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -13,7 +13,7 @@ window.HTMLImports.addModule(function(scope) {
 var path = scope.path;
 var rootDocument = scope.rootDocument;
 var flags = scope.flags;
-var isIE = scope.isIE;
+var isIE11OrOlder = scope.isIE11OrOlder;
 var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
 var IMPORT_SELECTOR = 'link[rel=' + IMPORT_LINK_TYPE + ']';
 
@@ -176,7 +176,7 @@ var importParser = {
   trackElement: function(elt, callback) {
     var self = this;
     var done = function(e) {
-      // make sure we don't get multiple load/error signals (FF seems to do 
+      // make sure we don't get multiple load/error signals (FF seems to do
       // this sometimes when <style> elments change)
       elt.removeEventListener('load', done);
       elt.removeEventListener('error', done);
@@ -191,7 +191,7 @@ var importParser = {
 
     // NOTE: IE does not fire "load" event for styles that have already loaded
     // This is in violation of the spec, so we try our hardest to work around it
-    if (isIE && elt.localName === 'style') {
+    if (isIE11OrOlder && elt.localName === 'style') {
       var fakeLoad = false;
       // If there's not @import in the textContent, assume it has loaded
       if (elt.textContent.indexOf('@import') == -1) {


### PR DESCRIPTION
Fixes https://github.com/webcomponents/webcomponentsjs/issues/366 

Also fixes the following tests on Edge:

ShadowCss
  * html/style-import-base-tag.html

Document
  * document.registerElement attachedCallback, detatchedCallback
  * document.registerElement get reference, upgrade, rewrap
