### PR TITLE
Use basic ponyfill for requestAnimationFrame

### DIFF
--- a/src/CustomElements/boot.js
+++ b/src/CustomElements/boot.js
@@ -78,13 +78,16 @@ function bootstrap() {
   // async to ensure *native* custom elements upgrade prior to this
   // DOMContentLoaded can fire before elements upgrade (e.g. when there's
   // an external script)
-  // Delay doubly to help workaround 
+  // Delay doubly to help workaround
   // https://code.google.com/p/chromium/issues/detail?id=516550.
-  // CustomElements must use requestAnimationFrame in attachedCallback 
+  // CustomElements must use requestAnimationFrame in attachedCallback
   // to query style/layout data. The WebComponentsReady event is intended
-  // to convey overall readiness, which ideally should be after elements 
-  // are attached. Adding a slight extra delay to WebComponentsReady 
+  // to convey overall readiness, which ideally should be after elements
+  // are attached. Adding a slight extra delay to WebComponentsReady
   // helps preserve this guarantee.
+  var requestAnimationFrame = window.requestAnimationFrame || function(f) {
+    setTimeout(f, 16);
+  };
   requestAnimationFrame(function() {
     setTimeout(function() {
       // capture blunt profiling data


### PR DESCRIPTION
in CustomElements.js

Fixes an error in certain old (and probably technically
unsupported) Android browsers.