### PR TITLE
Use the inert `contentDoc` to create `content` fragment. Fixes #379.

### DIFF
--- a/src/Template/Template.js
+++ b/src/Template/Template.js
@@ -29,7 +29,7 @@ if (typeof HTMLTemplateElement === 'undefined') {
     */
     HTMLTemplateElement.decorate = function(template) {
       if (!template.content) {
-        template.content = template.ownerDocument.createDocumentFragment();
+        template.content = contentDoc.createDocumentFragment();
       }
       var child;
       while (child = template.firstChild) {


### PR DESCRIPTION
The webcomponents-lite Template polyfill creates the content doc frag using the template's ownerDocument (usually the main document), resulting in upgraded elements when calling createElement; instead it should use the "inert" contentDoc document used by the innerHTML implementation that does not have createElement patched by the CustomElements polyfill (akin to the native template's content ownerDocument having a different separate and typically empty custom element registry from the main document).