### PR TITLE
Rationalize our isIE variables.

### DIFF
--- a/src/CustomElements/base.js
+++ b/src/CustomElements/base.js
@@ -30,6 +30,7 @@ var initializeModules = function() {
 scope.addModule = addModule;
 scope.initializeModules = initializeModules;
 scope.hasNative = Boolean(document.registerElement);
+scope.isIE = /Trident/.test(navigator.userAgent);
 
 // NOTE: For consistent timing, use native custom elements only when not
 // polyfilling other key related web components features.

--- a/src/CustomElements/boot.js
+++ b/src/CustomElements/boot.js
@@ -13,7 +13,7 @@
 var useNative = scope.useNative;
 var initializeModules = scope.initializeModules;
 
-var isIE11OrOlder = /Trident/.test(navigator.userAgent);
+var isIE = scope.isIE;
 
 // If native, setup stub api and bail.
 // NOTE: we fire `WebComponentsReady` under native for api compatibility
@@ -102,7 +102,7 @@ function bootstrap() {
 
 // CustomEvent shim for IE <= 11
 // NOTE: we explicitly test for IE since Safari has a type `object` CustomEvent
-if (isIE11OrOlder && (typeof window.CustomEvent !== 'function')) {
+if (isIE && (typeof window.CustomEvent !== 'function')) {
   window.CustomEvent = function(inType, params) {
     params = params || {};
     var e = document.createEvent('CustomEvent');
@@ -139,8 +139,5 @@ if (document.readyState === 'complete' || scope.flags.eager) {
       'HTMLImportsLoaded' : 'DOMContentLoaded';
   window.addEventListener(loadEvent, bootstrap);
 }
-
-// exports
-scope.isIE11OrOlder = isIE11OrOlder;
 
 })(window.CustomElements);

--- a/src/CustomElements/register.js
+++ b/src/CustomElements/register.js
@@ -21,7 +21,7 @@
 window.CustomElements.addModule(function(scope) {
 
 // imports
-var isIE11OrOlder = scope.isIE11OrOlder;
+var isIE = scope.isIE;
 var upgradeDocumentTree = scope.upgradeDocumentTree;
 var upgradeAll = scope.upgradeAll;
 var upgradeWithDefinition = scope.upgradeWithDefinition;
@@ -353,7 +353,7 @@ wrapDomMethodToForceUpgrade(document, 'importNode');
 // Patch document.importNode to work around IE11 bug that
 // casues children of a document fragment imported while
 // there is a mutation observer to not have a parentNode (!?!)
-if (isIE11OrOlder) {
+if (isIE) {
   (function() {
     var importNode = document.importNode;
     document.importNode = function() {

--- a/src/ShadowDOM/wrappers/Node.js
+++ b/src/ShadowDOM/wrappers/Node.js
@@ -349,9 +349,9 @@
   var originalRemoveChild = OriginalNode.prototype.removeChild;
   var originalReplaceChild = OriginalNode.prototype.replaceChild;
 
-  var isIe = /Trident|Edge/.test(navigator.userAgent);
+  var isIEOrEdge = /Trident|Edge/.test(navigator.userAgent);
 
-  var removeChildOriginalHelper = isIe ?
+  var removeChildOriginalHelper = isIEOrEdge ?
       function(parent, child) {
         try {
           originalRemoveChild.call(parent, child);


### PR DESCRIPTION
In CustomElements we were setting scope.isIE11OrOlder in boot.js rather than
base.js, such that it was undefined in register.js

Also switched to a more consistent naming scheme. isIE matches IE and
isIEOrEdge matches IE or Edge.

Fixes https://github.com/Polymer/polymer/issues/2310