### PR TITLE
Change import selectors to allow for imports with additional relation types

### DIFF
--- a/src/CustomElements/traverse.js
+++ b/src/CustomElements/traverse.js
@@ -69,7 +69,7 @@ function _forDocumentTree(doc, cb, processingDocuments) {
     return;
   }
   processingDocuments.push(doc);
-  var imports = doc.querySelectorAll('link[rel=' + IMPORT_LINK_TYPE + ']');
+  var imports = doc.querySelectorAll('link[rel~=' + IMPORT_LINK_TYPE + ']');
   for (var i=0, l=imports.length, n; (i<l) && (n=imports[i]); i++) {
     if (n.import) {
       _forDocumentTree(n.import, cb, processingDocuments);

--- a/src/HTMLImports/base.js
+++ b/src/HTMLImports/base.js
@@ -25,6 +25,7 @@ window.HTMLImports = window.HTMLImports || {flags:{}};
   the code later, only if it's necessary for polyfilling.
 */
 var IMPORT_LINK_TYPE = 'import';
+var IMPORT_SELECTOR = 'link[rel~=' + IMPORT_LINK_TYPE + ']';
 var useNative = Boolean(IMPORT_LINK_TYPE in document.createElement('link'));
 
 /**
@@ -114,7 +115,7 @@ function markTargetLoaded(event) {
 
 // call <callback> when we ensure all imports have loaded
 function watchImportsLoad(callback, doc) {
-  var imports = doc.querySelectorAll('link[rel=import]');
+  var imports = doc.querySelectorAll(IMPORT_SELECTOR);
   var parsedCount = 0, importCount = imports.length, newImports = [], errorImports = [];
   function checkDone() {
     if (parsedCount == importCount && callback) {
@@ -163,6 +164,15 @@ function isImportLoaded(link) {
       link.__importParsed;
 }
 
+// Check whether a given element node is a link with 'import' as one
+// of its relation types
+function isImport(element) {
+  if (element.localName !== 'link') return false;
+  var rels = element.getAttribute('rel');
+  if (rels === '' || rels === null) return false;
+  return rels.split(' ').indexOf(IMPORT_LINK_TYPE) !== -1;
+}
+
 // TODO(sorvell): Workaround for
 // https://www.w3.org/Bugs/Public/show_bug.cgi?id=25007, should be removed when
 // this bug is addressed.
@@ -191,10 +201,6 @@ if (useNative) {
     }
   }
 
-  function isImport(element) {
-    return element.localName === 'link' && element.rel === 'import';
-  }
-
   function handleImport(element) {
     var loaded = element.import;
     if (loaded) {
@@ -209,7 +215,7 @@ if (useNative) {
   // when this script is run.
   (function() {
     if (document.readyState === 'loading') {
-      var imports = document.querySelectorAll('link[rel=import]');
+      var imports = document.querySelectorAll(IMPORT_SELECTOR);
       for (var i=0, l=imports.length, imp; (i<l) && (imp=imports[i]); i++) {
         handleImport(imp);
       }
@@ -232,9 +238,11 @@ whenReady(function(detail) {
 
 // exports
 scope.IMPORT_LINK_TYPE = IMPORT_LINK_TYPE;
+scope.IMPORT_SELECTOR = IMPORT_SELECTOR;
 scope.useNative = useNative;
 scope.rootDocument = rootDocument;
 scope.whenReady = whenReady;
 scope.isIE = isIE;
+scope.isImport = isImport;
 
 })(window.HTMLImports);

--- a/src/HTMLImports/importer.js
+++ b/src/HTMLImports/importer.js
@@ -17,6 +17,7 @@ var rootDocument = scope.rootDocument;
 var Loader = scope.Loader;
 var Observer = scope.Observer;
 var parser = scope.parser;
+var isImport = scope.isImport;
 
 // importer
 // highlander object to manage loading of imports
@@ -67,7 +68,7 @@ var importer = {
     // see https://code.google.com/p/chromium/issues/detail?id=249381.
     elt.__resource = resource;
     elt.__error = err;
-    if (isImportLink(elt)) {
+    if (isImport(elt)) {
       var doc = this.documents[url];
       // if we've never seen a document at this url
       if (doc === undefined) {
@@ -110,14 +111,6 @@ var importLoader = new Loader(importer.loaded.bind(importer),
 // NOTE: the observer has a node added callback and this is set
 // by the dynamic importer module.
 importer.observer = new Observer();
-
-function isImportLink(elt) {
-  return isLinkRel(elt, IMPORT_LINK_TYPE);
-}
-
-function isLinkRel(elt, rel) {
-  return elt.localName === 'link' && elt.getAttribute('rel') === rel;
-}
 
 function hasBaseURIAccessor(doc) {
   return !! Object.getOwnPropertyDescriptor(doc, 'baseURI');

--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -15,7 +15,8 @@ var rootDocument = scope.rootDocument;
 var flags = scope.flags;
 var isIE = scope.isIE;
 var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
-var IMPORT_SELECTOR = 'link[rel=' + IMPORT_LINK_TYPE + ']';
+var IMPORT_SELECTOR = scope.IMPORT_SELECTOR;
+var isImport = scope.isImport;
 
 // importParser
 // highlander object to manage parsing of imports
@@ -136,7 +137,7 @@ var importParser = {
   },
 
   parseLink: function(linkElt) {
-    if (nodeIsImport(linkElt)) {
+    if (isImport(linkElt)) {
       this.parseImport(linkElt);
     } else {
       // make href absolute
@@ -258,7 +259,7 @@ var importParser = {
       for (var i=0, l=nodes.length, p=0, n; (i<l) && (n=nodes[i]); i++) {
         if (!this.isParsed(n)) {
           if (this.hasResource(n)) {
-            return nodeIsImport(n) ? this.nextToParseInDoc(n.__doc, n) : n;
+            return isImport(n) ? this.nextToParseInDoc(n.__doc, n) : n;
           } else {
             return;
           }
@@ -290,17 +291,13 @@ var importParser = {
   },
 
   hasResource: function(node) {
-    if (nodeIsImport(node) && (node.__doc === undefined)) {
+    if (isImport(node) && (node.__doc === undefined)) {
       return false;
     }
     return true;
   }
 
 };
-
-function nodeIsImport(elt) {
-  return (elt.localName === 'link') && (elt.rel === IMPORT_LINK_TYPE);
-}
 
 function generateScriptDataUrl(script) {
   var scriptContent = generateScriptContent(script);
@@ -334,6 +331,5 @@ function cloneStyle(style) {
 
 // exports
 scope.parser = importParser;
-scope.IMPORT_SELECTOR = IMPORT_SELECTOR;
 
 });

--- a/tests/HTMLImports/html/dynamic-with-addl-rels.html
+++ b/tests/HTMLImports/html/dynamic-with-addl-rels.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>HTML Imports Dynamic with additional relation types</title>
+    <script src="../../tools/htmltest.js"></script>
+    <script src="../../tools/chai/chai.js"></script>
+    <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+  </head>
+  <body>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        // some time later
+        setTimeout(function() {
+          var div = document.createElement('div');
+          div.innerHTML = '<link rel="import some-rel" href="imports/load-1.html">' +
+              '<link rel="otherRelType import" href="imports/load-2.html">';
+          document.body.appendChild(div);
+          var ports = document.querySelectorAll('link[rel~=import]');
+          var loads = 0;
+          for (var i=0, l=ports.length, n; (i<l) && (n=ports[i]); i++) {
+            n.addEventListener('load', function(e) {
+              loads++;
+              chai.assert.ok(e.target.import);
+            });
+          }
+          HTMLImports.whenReady(function() {
+            chai.assert.equal(loads, 2);
+            done();
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/HTMLImports/html/load-with-addl-rels.html
+++ b/tests/HTMLImports/html/load-with-addl-rels.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>load event Test with additional relation types</title>
+    <script>
+      window.loadEvents = 0;
+      (function() {
+        function importLoaded(event) {
+          window.loadEvents++;
+          if (event.type === 'load' && event.target.import) {
+            var s = event.target.import.querySelector('script');
+            chai.assert.ok(s, 'load event target can be used to find element in import');
+          }
+        }
+
+        function importError(event) {
+          window.loadEvents++;
+        }
+
+        window.importLoaded = importLoaded;
+        window.importError = importError;
+      })();
+    </script>
+    <script src="../../tools/htmltest.js"></script>
+    <script src="../../tools/chai/chai.js"></script>
+    <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+    <link rel="import some-rel" href="imports/load-1.html" onload="importLoaded(event)">
+    <link rel="otherRelType import" href="imports/load-2.html" onload="importLoaded(event)">
+    <link rel="import some-rel" id="willError" href="imports/404.html" onerror="importError(event)">
+    <link rel="otherRelType import" id="nohref" onerror="importError(event)">
+  </head>
+  <body>
+    <div id="test1" class="red">Test</div>
+    <div id="test2" class="blue">Test</div>
+    <div id="test3" class="image"></div>
+    <script>
+      document.addEventListener('HTMLImportsLoaded', function() {
+        chai.assert.equal(loadEvents, 4, 'expected # of load events');
+        var test1 = getComputedStyle(document.querySelector('#test1')).backgroundColor;
+        chai.assert.equal(test1, 'rgb(255, 0, 0)');
+        var test2 = getComputedStyle(document.querySelector('#test2')).backgroundColor;
+        chai.assert.equal(test2, 'rgb(0, 0, 255)');
+        done();
+      });
+    </script>
+  </body>
+</html>

--- a/tests/HTMLImports/tests.js
+++ b/tests/HTMLImports/tests.js
@@ -17,6 +17,7 @@ htmlSuite('HTMLImports', function() {
   htmlTest('html/load.html');
   htmlTest('html/load-404.html');
   htmlTest('html/load-loop.html');
+  htmlTest('html/load-with-addl-rels.html');
   htmlTest('html/base/load-base.html');
   htmlTest('html/currentScript.html');
   htmlTest('html/dedupe.html');
@@ -24,6 +25,7 @@ htmlSuite('HTMLImports', function() {
   htmlTest('html/dynamic-all-imports-detail.html');
   htmlTest('html/dynamic-errors-detail.html');
   htmlTest('html/dynamic-loaded-detail.html');
+  htmlTest('html/dynamic-with-addl-rels.html');
   htmlTest('html/csp.html');
   htmlTest('html/customevent-detail.html');
   htmlTest('html/encoding.html');


### PR DESCRIPTION
I noticed in Chrome that the native imports functionality allows for additional relation types, but in browsers where the polyfill is used, those imports would not be processed. 

As a developer I want to be able to specify additional relation types for imports so that I can perform additional processing of certain imports using the established concept of relations (and extension relations) rather than `data-*` attributes.
