### PR TITLE
Use self instead of this to refer to window/context

### DIFF
--- a/src/MutationObserver/MutationObserver.js
+++ b/src/MutationObserver/MutationObserver.js
@@ -565,4 +565,4 @@
     global.MutationObserver = JsMutationObserver;
 
 
-})(window);
+})(self);

--- a/src/URL/URL.js
+++ b/src/URL/URL.js
@@ -613,4 +613,4 @@
 
   scope.URL = jURL;
 
-})(this);
+})(self);


### PR DESCRIPTION
R: @garlicnation 

This fixes an issue when running the wc.js polyfill through vulcanize + babel. The issue stems from the fact that Babel [redefines the top level `this` to `undefined`](https://github.com/babel/babel/commit/fb360039cea6c7e8e4f09458b518b1fcf45d0d74) to match module semantics. Due to this, if you try to vulcanize index.html and then run babeljs over the .js from cripser, you'll get this output:

```
  }
  scope.URL = jURL;
})(undefined);
```

The simple fix is to use `self` to refer to window instead of `this`. I'm [not a good reason `this` was used in the first place](https://github.com/Polymer/URL/commit/51ab442b462e3386b628a0bc135f4123f588d559#comments). `self` is a better choice to refer to `window`.

Technically, one shouldn't be using babel on an file not written for es6, but this fix is simple enough to make things work. I think we should do it to support users.