### PR TITLE
Transforms Node.childNodes into a live NodeList

### DIFF
--- a/src/ShadowDOM/wrappers/HTMLElement.js
+++ b/src/ShadowDOM/wrappers/HTMLElement.js
@@ -23,6 +23,7 @@
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
   var wrappers = scope.wrappers;
+  var rebuildChildNodes = scope.rebuildChildNodes;
 
   /////////////////////////////////////////////////////////////////////////////
   // innerHTML and outerHTML
@@ -204,6 +205,10 @@
         setInnerHTML(this.content, value);
       } else {
         unsafeUnwrap(this).innerHTML = value;
+
+        if (this.childNodes_ !== undefined) {
+          rebuildChildNodes(this);
+        }
       }
 
       var addedNodes = snapshotNodeList(this.childNodes);

--- a/src/ShadowDOM/wrappers/Node.js
+++ b/src/ShadowDOM/wrappers/Node.js
@@ -366,8 +366,11 @@
 
     this.treeScope_ = undefined;
 
+    /**
+     * @type {NodeList|undefined}
+     * @private
+     */
     this.childNodes_ = undefined;
-    this.children_ = undefined;
   }
 
   var OriginalDocumentFragment = window.DocumentFragment;

--- a/src/ShadowDOM/wrappers/NodeList.js
+++ b/src/ShadowDOM/wrappers/NodeList.js
@@ -49,8 +49,76 @@
     };
   }
 
+  function removeItemAtNodeList(list, index) {
+    var i, length;
+
+    length = --list.length;
+
+    for (i = index; i < length; i++) {
+      list[i] = list[i + 1];
+    }
+
+    delete list[length];
+  }
+
+  function insertBeforeNodeList(list, item, ref) {
+    var i;
+
+    if (ref) {
+      for (i = list.length++; i > 0 && list[i] !== ref; i--) {
+        list[i] = list[i - 1];
+      }
+    } else {
+      i = list.length++;
+    }
+
+    list[i] = item;
+  }
+
+  function indexOfNodeList(list, item) {
+    var i;
+    var length = list.length;
+
+    for (i = 0; i < length; i++) {
+      if (list[i] === item) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  function clearNodeList(list) {
+    var i, length = list.length;
+
+    for (i = 0; i < length; i++) {
+      delete list[i];
+    }
+
+    list.length = 0;
+  }
+
+  function copyNodeList(dest, src) {
+    var i, length = src.length, oldLength = dest.length;
+
+    for (i = 0; i < length; i++) {
+      dest[i] = src[i];
+    }
+
+    while (i < oldLength) {
+      delete dest[i++];
+    }
+
+    dest.length = length;
+  }
+
   scope.wrappers.NodeList = NodeList;
   scope.addWrapNodeListMethod = addWrapNodeListMethod;
   scope.wrapNodeList = wrapNodeList;
+  scope.removeItemAtNodeList = removeItemAtNodeList;
+  scope.insertBeforeNodeList = insertBeforeNodeList;
+  scope.clearNodeList = clearNodeList;
+  scope.indexOfNodeList = indexOfNodeList;
+  scope.copyNodeList = copyNodeList;
 
 })(window.ShadowDOMPolyfill);

--- a/tests/ShadowDOM/js/Node.js
+++ b/tests/ShadowDOM/js/Node.js
@@ -472,84 +472,105 @@ suite('Node', function() {
    * in the nodes returned by the NodeList accessors; it is not a static
    * snapshot of the content of the node".
    */
-  test('live childNodes consistency after child removal - issue 321', function() {
-    var a = document.createElement('a');
-    var b = document.createElement('b');
+  suite('live childNodes consistency (issue 321)', function() {
+    test('after child removal', function() {
+      var a = document.createElement('a');
+      var b = document.createElement('b');
 
-    a.appendChild(b);
+      a.appendChild(b);
 
-    var childNodes = a.childNodes;
-    assert.equal(childNodes.length, 1);
-    
-    a.removeChild(b);
-    assert.equal(a.childNodes.length, 0);
-    assert.equal(childNodes.length, 0);
-  });
+      var childNodes = a.childNodes;
+      assert.equal(childNodes.length, 1);
+      
+      a.removeChild(b);
+      assert.equal(a.childNodes.length, 0);
+      assert.equal(childNodes.length, 0);
+    });
 
-  test('live childNodes consistency after child appended - issue 321', function() {
-    var node = document.createElement('a');
+    test('after child appended', function() {
+      var node = document.createElement('a');
 
-    var childNodes = node.childNodes;
-    assert.equal(childNodes.length, 0);
+      var childNodes = node.childNodes;
+      assert.equal(childNodes.length, 0);
 
-    node.appendChild(document.createElement('b'));
-    assert.equal(node.childNodes.length, 1);
-    assert.equal(childNodes.length, 1);
-  });
+      node.appendChild(document.createElement('b'));
+      assert.equal(node.childNodes.length, 1);
+      assert.equal(childNodes.length, 1);
+    });
 
-  test('live childNodes consistency after child inserted before - issue 321', function() {
-    var node = document.createElement('a');
-    var child = document.createElement('b')
-    
-    node.appendChild(child);
+    test('after child inserted before', function() {
+      var node = document.createElement('a');
+      var child = document.createElement('b');
+      
+      node.appendChild(child);
 
-    var childNodes = node.childNodes;
-    assert.equal(childNodes.length, 1);
+      var childNodes = node.childNodes;
+      assert.equal(childNodes.length, 1);
 
-    var firstChild = document.createElement('c');
-    node.insertBefore(firstChild, child);
-    assert.equal(node.childNodes.length, 2);
-    assert.equal(childNodes.length, 2);
-    assert.equal(childNodes[0], node.childNodes[0]);
-    assert.equal(childNodes[1], node.childNodes[1]);
-    assert.equal(childNodes[0], firstChild);
-    assert.equal(childNodes[1], child);    
-  });
+      var firstChild = document.createElement('c');
+      node.insertBefore(firstChild, child);
+      assert.equal(node.childNodes.length, 2);
+      assert.equal(childNodes.length, 2);
+      assert.equal(childNodes[0], node.childNodes[0]);
+      assert.equal(childNodes[1], node.childNodes[1]);
+      assert.equal(childNodes[0], firstChild);
+      assert.equal(childNodes[1], child);    
+    });
 
-  test('live childNodes consistency after textContent changed - issue 321', function() {
-    var node = document.createElement('a');
-    var child = document.createElement('b')
-    
-    node.appendChild(child);
+    test('after textContent changed', function() {
+      var node = document.createElement('a');
+      var child = document.createElement('b');
+      
+      node.appendChild(child);
 
-    var childNodes = node.childNodes;
-    assert.equal(childNodes.length, 1);
-    assert.equal(childNodes[0], child);
+      var childNodes = node.childNodes;
+      assert.equal(childNodes.length, 1);
+      assert.equal(childNodes[0], child);
 
-    node.textContent = 'text';
+      node.textContent = 'text';
 
-    assert.equal(node.childNodes.length, 1);
-    assert.equal(childNodes.length, 1);
-    assert.equal(node.childNodes[0], childNodes[0]);
-    assert.notEqual(childNodes[0], child);
-  });
+      assert.equal(node.childNodes.length, 1);
+      assert.equal(childNodes.length, 1);
+      assert.equal(node.childNodes[0], childNodes[0]);
+      assert.notEqual(childNodes[0], child);
+    });
 
-  test('live childNodes consistency after innerHTML changed - issue 321', function() {
-    var node = document.createElement('a');
-    var child = document.createElement('b')
-    
-    node.appendChild(child);
+    test('after innerHTML changed', function() {
+      var node = document.createElement('a');
+      var child = document.createElement('b');
+      
+      node.appendChild(child);
 
-    var childNodes = node.childNodes;
-    assert.equal(childNodes.length, 1);
-    assert.equal(childNodes[0], child);
+      var childNodes = node.childNodes;
+      assert.equal(childNodes.length, 1);
+      assert.equal(childNodes[0], child);
 
-    node.innerHTML = '<span>test</span>';
+      node.innerHTML = '<span>test</span>';
 
-    assert.equal(node.childNodes.length, 1);
-    assert.equal(childNodes.length, 1);
-    assert.equal(node.childNodes[0], childNodes[0]);
-    assert.notEqual(childNodes[0], child);  
+      assert.equal(node.childNodes.length, 1);
+      assert.equal(childNodes.length, 1);
+      assert.equal(node.childNodes[0], childNodes[0]);
+      assert.notEqual(childNodes[0], child);  
+    });
+
+    test('after replaceChild', function() {
+      var node = document.createElement('a');
+      var child = document.createElement('b');
+      
+      node.appendChild(child);
+
+      var childNodes = node.childNodes;
+      assert.equal(childNodes.length, 1);
+      assert.equal(childNodes[0], child);
+
+      var newChild = document.createElement('c');
+      node.replaceChild(newChild, child);
+
+      assert.equal(node.childNodes.length, 1);
+      assert.equal(childNodes.length, 1);
+      assert.equal(node.childNodes[0], childNodes[0]);
+      assert.notEqual(childNodes[0], child);  
+    });
   });
 
 });

--- a/tests/ShadowDOM/js/Node.js
+++ b/tests/ShadowDOM/js/Node.js
@@ -466,4 +466,90 @@ suite('Node', function() {
     assert.isFalse(div.isEqualNode(clone));
   });
 
+  /* According to DOM Level 1, "the content of the returned NodeList is
+   * 'live' in the sense that, for instance, changes to the children of
+   * the node object that it was created from are immediately reflected
+   * in the nodes returned by the NodeList accessors; it is not a static
+   * snapshot of the content of the node".
+   */
+  test('live childNodes consistency after child removal - issue 321', function() {
+    var a = document.createElement('a');
+    var b = document.createElement('b');
+
+    a.appendChild(b);
+
+    var childNodes = a.childNodes;
+    assert.equal(childNodes.length, 1);
+    
+    a.removeChild(b);
+    assert.equal(a.childNodes.length, 0);
+    assert.equal(childNodes.length, 0);
+  });
+
+  test('live childNodes consistency after child appended - issue 321', function() {
+    var node = document.createElement('a');
+
+    var childNodes = node.childNodes;
+    assert.equal(childNodes.length, 0);
+
+    node.appendChild(document.createElement('b'));
+    assert.equal(node.childNodes.length, 1);
+    assert.equal(childNodes.length, 1);
+  });
+
+  test('live childNodes consistency after child inserted before - issue 321', function() {
+    var node = document.createElement('a');
+    var child = document.createElement('b')
+    
+    node.appendChild(child);
+
+    var childNodes = node.childNodes;
+    assert.equal(childNodes.length, 1);
+
+    var firstChild = document.createElement('c');
+    node.insertBefore(firstChild, child);
+    assert.equal(node.childNodes.length, 2);
+    assert.equal(childNodes.length, 2);
+    assert.equal(childNodes[0], node.childNodes[0]);
+    assert.equal(childNodes[1], node.childNodes[1]);
+    assert.equal(childNodes[0], firstChild);
+    assert.equal(childNodes[1], child);    
+  });
+
+  test('live childNodes consistency after textContent changed - issue 321', function() {
+    var node = document.createElement('a');
+    var child = document.createElement('b')
+    
+    node.appendChild(child);
+
+    var childNodes = node.childNodes;
+    assert.equal(childNodes.length, 1);
+    assert.equal(childNodes[0], child);
+
+    node.textContent = 'text';
+
+    assert.equal(node.childNodes.length, 1);
+    assert.equal(childNodes.length, 1);
+    assert.equal(node.childNodes[0], childNodes[0]);
+    assert.notEqual(childNodes[0], child);
+  });
+
+  test('live childNodes consistency after innerHTML changed - issue 321', function() {
+    var node = document.createElement('a');
+    var child = document.createElement('b')
+    
+    node.appendChild(child);
+
+    var childNodes = node.childNodes;
+    assert.equal(childNodes.length, 1);
+    assert.equal(childNodes[0], child);
+
+    node.innerHTML = '<span>test</span>';
+
+    assert.equal(node.childNodes.length, 1);
+    assert.equal(childNodes.length, 1);
+    assert.equal(node.childNodes[0], childNodes[0]);
+    assert.notEqual(childNodes[0], child);  
+  });
+
 });


### PR DESCRIPTION
Transforms `Node.childNodes` into a live `NodeList` - fixes #321 

According to [DOM Level 1 Specification](http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html), regarding to childNodes attribute:

> The content of the returned NodeList is 'live' in the sense that, for instance, changes to the children of the node object that it was created from are immediately reflected in the nodes returned by the NodeList accessors; it is not a static snapshot of the content of the node.

This changeset introduces a permanent reference for `childNodes` `NodeList` that is created on-demand. Once created, it's continuously updated on node operations, such as `appendChild`, `insertBefore`, `removeChild`, set `textContent` and `innerHTML`.

No performance issues were realized, during tests on Firefox 39. Without the fix, the tests runned in 28.670 seconds (mean of 5 consecutive tests). With the fix, 28.746 seconds.
