### PR TITLE
Make flags.log check more expressive #180

### DIFF
--- a/webcomponents.js
+++ b/webcomponents.js
@@ -9,6 +9,10 @@
  */
 
 (function() {
+  // Helper function to check if given source is a string or not
+  function isString(source) {
+    return Object.prototype.toString.call(source) === '[object String]';
+  }
 
   // Establish scope.
   window.WebComponents = window.WebComponents || {flags:{}};
@@ -37,7 +41,7 @@
       }
     }
     // log flags
-    if (flags.log && flags.log.split) {
+    if (isString(flags.log)) {
       var parts = flags.log.split(',');
       flags.log = {};
       parts.forEach(function(f) {


### PR DESCRIPTION
## Bug story

Requiring `webcomponents.min.js` leads to having #180 error. As far as I understand, this issue has been fixed #223, but I think we can use more expressive way for this.
## What have been done

Replaced `flags.log && flags.log.split` by `isString(flags.log)`. There are to ideas behind this change:
- Express that `flags.log` should be a `String` to match this case
- Avoid possible mistakes by passing object that have `split` method, but not `String`

I hope you will consider this minor change meaningful.

P.S. Please, bump a bower package version with this fix.
