### PR TITLE
Include rAF polyfill in wc-lite builds

### DIFF
--- a/src/WebComponents/build-lite.json
+++ b/src/WebComponents/build-lite.json
@@ -6,5 +6,6 @@
   "../HTMLImports/build.json",
   "../CustomElements/build.json",
   "../Template/Template.js",
+  "dom.js",
   "unresolved.js"
 ]

--- a/webcomponents-lite.js
+++ b/webcomponents-lite.js
@@ -57,6 +57,7 @@
     'CustomElements/CustomElements.js',
     'Template/Template.js',
     // these scripts are loaded here due to polyfill timing issues
+    'WebComponents/dom.js',
     'WebComponents/unresolved.js'
   ];
 


### PR DESCRIPTION
Address an issue where headless webkit instances may not have `window.requestAnimationFrame` and thus may cause scripts to stop executing when hitting this.

We currently already include dom.js (with a rAF polyfill) in the full wc.js builds. This change just ensures that it is also included in the lite builds too.