### PR TITLE
add check for log split before executing

### DIFF
--- a/src/WebComponents/build/boot-lite.js
+++ b/src/WebComponents/build/boot-lite.js
@@ -37,7 +37,7 @@ window.WebComponents = window.WebComponents || {};
       }
     }
     // log flags
-    if (flags.log) {
+    if (flags.log && flags.log.split) {
       var parts = flags.log.split(',');
       flags.log = {};
       parts.forEach(function(f) {


### PR DESCRIPTION
seems that this change was propagated to the boot.js but not to the boot-lite.js