### PR TITLE
Valid SPDX expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "url": "https://github.com/webcomponents/webcomponentsjs.git"
   },
   "author": "The Polymer Authors",
-  "license": {
-    "type": "BSD-3-Clause",
-    "url": "http://polymer.github.io/LICENSE.txt"
-  },
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/webcomponents/webcomponentsjs/issues"
   },


### PR DESCRIPTION
Fixes installation warning.
```
npm WARN package.json webcomponents.js@0.7.15 license should be a valid SPDX license expression
```