### PR TITLE
avoid TypeError on Firefox

### DIFF
--- a/src/ShadowDOM/TreeScope.js
+++ b/src/ShadowDOM/TreeScope.js
@@ -63,7 +63,7 @@
   }
 
   function getTreeScope(node) {
-    if (node instanceof scope.wrappers.Window) {
+    if (scope.wrappers.Window !== void 0 && node instanceof scope.wrappers.Window) {
       debugger;
     }
 


### PR DESCRIPTION
`TypeError: invalid 'instanceof' operand scope.wrappers.Window` error was showing on firefox, the `Window` object was undefined.
