### PR TITLE
Ignore "async" imports for HTMLImports.whenReady

### DIFF
--- a/src/HTMLImports/base.js
+++ b/src/HTMLImports/base.js
@@ -114,7 +114,7 @@ function markTargetLoaded(event) {
 
 // call <callback> when we ensure all imports have loaded
 function watchImportsLoad(callback, doc) {
-  var imports = doc.querySelectorAll('link[rel=import]');
+  var imports = doc.querySelectorAll('link[rel=import]:not([async])');
   var parsedCount = 0, importCount = imports.length, newImports = [], errorImports = [];
   function checkDone() {
     if (parsedCount == importCount && callback) {

--- a/tests/HTMLImports/html/HTMLImportsLoaded-native.html
+++ b/tests/HTMLImports/html/HTMLImportsLoaded-native.html
@@ -11,21 +11,21 @@
 <html>
   <head>
     <title>HTMLImportsLoaded, native</title>
-    <script>WCT = {waitFor: function(cb){ cb() }}</script>
     <script src="../../../src/HTMLImports/HTMLImports.js"></script>
     <script src="../../../../web-component-tester/browser.js"></script>
   </head>
   <body>
     <link rel="import" href="imports/import-1.html">
     <script>
-      test('HTMLImportsLoaded fires with native imports', function(done) {
+      var loaded
+      addEventListener('HTMLImportsLoaded', function() {
+        loaded = true;
+      });
+      test('HTMLImportsLoaded fires with native imports', function() {
         if (!HTMLImports.useNative) {
-          return done();
+          return;
         }
-        addEventListener('HTMLImportsLoaded', function(e) {
-          chai.assert.ok(true, 'HTMLImportsLoaded');
-          done();
-        });
+        chai.assert.ok(true, 'HTMLImportsLoaded');
       });
     </script>
   </body>

--- a/tests/HTMLImports/html/dynamic-loaded-detail.html
+++ b/tests/HTMLImports/html/dynamic-loaded-detail.html
@@ -36,6 +36,10 @@
 
       test('dynamic loaded details', function(done) {
         HTMLImports.whenReady(function(detail) {
+          if (HTMLImports.useNative) {
+            return done();
+          }
+
           chai.assert.equal(detail.allImports.length, 2);
           chai.assert.equal(detail.errorImports.length, 0);
           chai.assert.equal(detail.loadedImports.length, 2);

--- a/tests/HTMLImports/html/imports/async-async.html
+++ b/tests/HTMLImports/html/imports/async-async.html
@@ -1,0 +1,10 @@
+<!--
+    @license
+    Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<script>asyncLoaded++;</script>

--- a/tests/HTMLImports/html/imports/async-sync.html
+++ b/tests/HTMLImports/html/imports/async-sync.html
@@ -1,0 +1,10 @@
+<!--
+    @license
+    Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<script>syncLoaded++;</script>

--- a/tests/HTMLImports/html/whenready.html
+++ b/tests/HTMLImports/html/whenready.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+    @license
+    Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HTMLImports.whenReady ignores async</title>
+  <script>
+  WCT = {
+    waitFor: function(cb) { cb(); }
+  };
+  var asyncLoaded = 0;
+  var syncLoaded = 0;
+  </script>
+  <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+  <script src="../../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="imports/async-sync.html">
+  <link rel="import" href="imports/async-async.html">
+</head>
+<body>
+  <script>
+  test('whenReady ignores async', function(done) {
+    HTMLImports.whenReady(function (detail) {
+      assert(detail.loadedImports, 1, 'whenReady should wait for the sync import');
+      done();
+    });
+  });
+  test('Eventually all imports load', function(done) {
+    setTimeout(function() {
+      assert.equal(syncLoaded, 1, 'sync load count incorrect');
+      assert.equal(asyncLoaded, 1, 'async load count incorrect');
+      done();
+    }, 2000);
+  });
+  </script>
+</body>
+</html>

--- a/tests/HTMLImports/html/whenready.html
+++ b/tests/HTMLImports/html/whenready.html
@@ -21,23 +21,28 @@
   </script>
   <script src="../../../src/HTMLImports/HTMLImports.js"></script>
   <script src="../../../../web-component-tester/browser.js"></script>
+  <link rel="import" async href="imports/async-async.html">
   <link rel="import" href="imports/async-sync.html">
-  <link rel="import" href="imports/async-async.html">
 </head>
 <body>
   <script>
-  test('whenReady ignores async', function(done) {
-    HTMLImports.whenReady(function (detail) {
-      assert(detail.loadedImports, 1, 'whenReady should wait for the sync import');
-      done();
+  suite('HTMLImports.whenReady with async', function() {
+    var testFn = HTMLImports.useNative ? test.skip : test;
+
+    testFn('whenReady ignores async', function(done) {
+      HTMLImports.whenReady(function (detail) {
+        assert.equal(detail.loadedImports.length, 1, 'whenReady should wait for the sync import');
+        assert.equal(syncLoaded, 1, 'sync load count incorrect');
+        done();
+      });
     });
-  });
-  test('Eventually all imports load', function(done) {
-    setTimeout(function() {
-      assert.equal(syncLoaded, 1, 'sync load count incorrect');
-      assert.equal(asyncLoaded, 1, 'async load count incorrect');
-      done();
-    }, 2000);
+    testFn('Eventually all imports load', function(done) {
+      setTimeout(function() {
+        assert.equal(syncLoaded, 1, 'sync load count incorrect');
+        assert.equal(asyncLoaded, 1, 'async load count incorrect');
+        done();
+      }, 2000);
+    });
   });
   </script>
 </body>


### PR DESCRIPTION
Fixes #431
