### PR TITLE
Fix event.defaultPrevented for IE

### DIFF
--- a/src/CustomElements/boot.js
+++ b/src/CustomElements/boot.js
@@ -113,6 +113,9 @@ if (!window.CustomEvent || isIE && (typeof window.CustomEvent !== 'function')) {
     // CustomEvents
     // http://stackoverflow.com/questions/23349191/event-preventdefault-is-not-working-in-ie-11-for-custom-events
     e.preventDefault = function() {
+      if (!this.cancelable) {
+        return;
+      }
       Object.defineProperty(this, 'defaultPrevented', {
         get: function() {
           return true;

--- a/src/HTMLImports/boot.js
+++ b/src/HTMLImports/boot.js
@@ -36,6 +36,9 @@ if (!window.CustomEvent || isIE && (typeof window.CustomEvent !== 'function')) {
     // CustomEvents
     // http://stackoverflow.com/questions/23349191/event-preventdefault-is-not-working-in-ie-11-for-custom-events
     e.preventDefault = function() {
+      if (!this.cancelable) {
+        return;
+      }
       Object.defineProperty(this, 'defaultPrevented', {
         get: function() {
           return true;

--- a/src/ShadowDOM/wrappers/events.js
+++ b/src/ShadowDOM/wrappers/events.js
@@ -520,6 +520,29 @@
       stopImmediatePropagationTable.set(this, true);
     }
   };
+
+  // defaultPrevented is broken in IE.
+  // https://connect.microsoft.com/IE/feedback/details/790389/event-defaultprevented-returns-false-after-preventdefault-was-called
+  var supportsDefaultPrevented = (function() {
+    var e = document.createEvent('Event');
+    e.initEvent('test', true, true);
+    e.preventDefault();
+    return e.defaultPrevented;
+  })();
+
+  if (!supportsDefaultPrevented) {
+    Event.prototype.preventDefault = function() {
+      if (!this.cancelable)
+        return;
+      unsafeUnwrap(this).preventDefault();
+      Object.defineProperty(this, 'defaultPrevented', {
+        get: function() {
+          return true;
+        }
+      });
+    };
+  }
+
   registerWrapper(OriginalEvent, Event, document.createEvent('Event'));
 
   function unwrapOptions(options) {

--- a/tests/ShadowDOM/js/events.js
+++ b/tests/ShadowDOM/js/events.js
@@ -333,6 +333,18 @@ suite('Events', function() {
     assertArrayEqual(log, [a, Event.CAPTURING_PHASE, b, Event.CAPTURING_PHASE]);
   });
 
+  test('preventDefault sets defaultPrevented', function() {
+    // is not prevented when not cancelable
+    var e = new CustomEvent('foo');
+    e.preventDefault();
+    assert.isFalse(e.defaultPrevented);
+
+    // is prevented when cancelable
+    e = new CustomEvent('foo', {cancelable: true});
+    e.preventDefault();
+    assert.isTrue(e.defaultPrevented);
+  });
+
   test('click with shadow', function() {
     function addListener(target, currentTarget, opt_phase) {
       var phases;
@@ -1165,10 +1177,7 @@ test('retarget order (multiple shadow roots)', function() {
     div.click();
     assert.equal(calls, 2);
 
-    // defaultPrevented is broken in IE.
-    // https://connect.microsoft.com/IE/feedback/details/790389/event-defaultprevented-returns-false-after-preventdefault-was-called
-    if (!/Trident|Edge/.test(navigator.userAgent))
-      assert.isTrue(event.defaultPrevented);
+    assert.isTrue(event.defaultPrevented);
   });
 
   test('event.path (bubbles)', function() {


### PR DESCRIPTION
Only set defaultPrevented if event is cancelable
Add tests with and without cancelable
Fix shims in HTMLImports and CustomElements to support cancelable