### PR TITLE
polyfill support for slot element and ::slotted

### DIFF
--- a/src/ShadowCSS/ShadowCSS.js
+++ b/src/ShadowCSS/ShadowCSS.js
@@ -243,6 +243,14 @@ var ShadowCSS = {
    *
    * scopeName menu-item {
    *
+   * And this rule:
+   *
+   * polyfill-next-selector { slotted: ':host nav-item'; }
+   * ::slotted(nav-item) {
+   *
+   * to this:
+   *
+   * scopeName nav-item {
   **/
   insertPolyfillDirectivesInCssText: function(cssText) {
     // TODO(sorvell): remove either content or comment
@@ -387,12 +395,16 @@ var ShadowCSS = {
   },
   /*
    * Convert combinators like ::shadow and pseudo-elements like ::content
-   * by replacing with space.
+   * and ::slotted by replacing with space.
   */
   convertShadowDOMSelectors: function(cssText) {
     for (var i=0; i < shadowDOMSelectorsRe.length; i++) {
       cssText = cssText.replace(shadowDOMSelectorsRe[i], ' ');
     }
+    for (var i=0; i < shadowDOMSelectorFunctionsRe.length; i++) {
+      cssText = cssText.replace(shadowDOMSelectorFunctionsRe[i], '$1 ')
+    }
+
     return cssText;
   },
   // change a selector like 'div' to 'name div'
@@ -587,7 +599,10 @@ var selectorRe = /([^{]*)({[\s\S]*?})/gim,
       /\/shadow-deep\//g, // former /deep/
       /\^\^/g,     // former /shadow/
       /\^/g        // former /shadow-deep/
-    ];
+  ],
+  shadowDOMSelectorFunctionsRe = [
+      /::slotted\((.*)\)/g,
+  ];
 
 function stylesToCssText(styles, preserveComments) {
   var cssText = '';

--- a/src/ShadowDOM/ShadowDOM.js
+++ b/src/ShadowDOM/ShadowDOM.js
@@ -50,6 +50,7 @@ Array.prototype.forEach.call(document.querySelectorAll('script[src]'), function(
   'wrappers/HTMLAudioElement.js',
   'wrappers/HTMLOptionElement.js',
   'wrappers/HTMLSelectElement.js',
+  'wrappers/HTMLSlotElement.js',
   'wrappers/HTMLTableElement.js',
   'wrappers/HTMLTableSectionElement.js',
   'wrappers/HTMLTableRowElement.js',

--- a/src/ShadowDOM/build.json
+++ b/src/ShadowDOM/build.json
@@ -27,6 +27,7 @@
   "wrappers/HTMLAudioElement.js",
   "wrappers/HTMLOptionElement.js",
   "wrappers/HTMLSelectElement.js",
+  "wrappers/HTMLSlotElement.js",
   "wrappers/HTMLTableElement.js",
   "wrappers/HTMLTableSectionElement.js",
   "wrappers/HTMLTableRowElement.js",

--- a/src/ShadowDOM/querySelector.js
+++ b/src/ShadowDOM/querySelector.js
@@ -73,6 +73,11 @@
       .replace(
         /\^|\/shadow\/|\/shadow-deep\/|::shadow|\/deep\/|::content|>>>/g,
         ' '
+      )
+      // From ShadowCSS, will be replaced by function argument + space
+      .replace(
+        /\::slotted\((.*)\)/g,
+        '$1 '
       );
   }
 

--- a/src/ShadowDOM/wrappers/HTMLSlotElement.js
+++ b/src/ShadowDOM/wrappers/HTMLSlotElement.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+(function(scope) {
+  'use strict';
+
+  var HTMLElement = scope.wrappers.HTMLElement;
+  var mixin = scope.mixin;
+  var registerWrapper = scope.registerWrapper;
+
+  var OriginalHTMLSlotElement = window.HTMLSlotElement;
+
+  function HTMLSlotElement(node) {
+    HTMLElement.call(this, node);
+  }
+  HTMLSlotElement.prototype = Object.create(HTMLElement.prototype);
+  mixin(HTMLSlotElement.prototype, {
+    constructor: HTMLSlotElement,
+
+    get name() {
+      return this.getAttribute('name');
+    },
+    set name(value) {
+      this.setAttribute('name', value);
+    },
+
+    setAttribute: function(n, v) {
+      HTMLElement.prototype.setAttribute.call(this, n, v);
+      if (String(n).toLowerCase() === 'name')
+        this.invalidateShadowRenderer(true);
+    }
+
+    // getDistributedNodes is added in ShadowRenderer
+  });
+
+  if (OriginalHTMLSlotElement)
+    registerWrapper(OriginalHTMLSlotElement, HTMLSlotElement);
+
+  scope.wrappers.HTMLSlotElement = HTMLSlotElement;
+})(window.ShadowDOMPolyfill);

--- a/src/ShadowDOM/wrappers/HTMLUnknownElement.js
+++ b/src/ShadowDOM/wrappers/HTMLUnknownElement.js
@@ -14,6 +14,7 @@
   var HTMLContentElement = scope.wrappers.HTMLContentElement;
   var HTMLElement = scope.wrappers.HTMLElement;
   var HTMLShadowElement = scope.wrappers.HTMLShadowElement;
+  var HTMLSlotElement = scope.wrappers.HTMLSlotElement;
   var HTMLTemplateElement = scope.wrappers.HTMLTemplateElement;
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
@@ -22,6 +23,8 @@
 
   function HTMLUnknownElement(node) {
     switch (node.localName) {
+      case 'slot':
+        return new HTMLSlotElement(node);
       case 'content':
         return new HTMLContentElement(node);
       case 'shadow':

--- a/src/ShadowDOM/wrappers/override-constructors.js
+++ b/src/ShadowDOM/wrappers/override-constructors.js
@@ -77,6 +77,7 @@
     'shadow': 'HTMLShadowElement',
     'source': 'HTMLSourceElement',
     'span': 'HTMLSpanElement',
+    'slot': 'HTMLSlotElement',
     'style': 'HTMLStyleElement',
     'table': 'HTMLTableElement',
     'tbody': 'HTMLTableSectionElement',

--- a/tests/ShadowDOM/js/HTMLSlotElement.js
+++ b/tests/ShadowDOM/js/HTMLSlotElement.js
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('HTMLContentElement', function() {
+
+  var unwrap = ShadowDOMPolyfill.unwrap;
+
+  test('select', function() {
+    var el = document.createElement('slot');
+    assert.equal(el.name, null);
+
+    el.name = 'xxx';
+    assert.equal(el.name, '.xxx');
+    assert.isTrue(el.hasAttribute('name'));
+    assert.equal(el.getAttribute('name'), 'xxx');
+  });
+
+  test('getDistributedNodes', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a slot="a">a</a><b slot="b">b</b>';
+    var a = host.firstChild;
+    var b = a.lastChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<slot></slot>';
+    var slot = sr.firstChild;
+
+    assertArrayEqual(slot.getDistributedNodes(), [a, b]);
+
+    slot.name = 'a';
+    assertArrayEqual(content.getDistributedNodes(), [a]);
+
+    content.name = 'b';
+    assertArrayEqual(content.getDistributedNodes(), [b]);
+  });
+
+  test('getDistributedNodes add document fragment with slot', function() {
+    var host = document.createElement('div');
+    host.innerHTML = ' <a></a> <a></a> <a></a> ';
+    var root = host.createShadowRoot();
+    var df = document.createDocumentFragment();
+    df.appendChild(document.createTextNode(' '));
+    var slot = df.appendChild(document.createElement('slot'));
+    df.appendChild(document.createTextNode(' '));
+    root.appendChild(df);
+
+    assert.equal(slot.getDistributedNodes().length, 7);
+    assertArrayEqual(slot.getDistributedNodes(), host.childNodes);
+  });
+
+  test('getDistributedNodes add slot deep inside tree', function() {
+    var host = document.createElement('div');
+    host.innerHTML = ' <a></a> <a></a> <a></a> ';
+    var root = host.createShadowRoot();
+    var b = document.createElement('b');
+    var slot = b.appendChild(document.createElement('slot'));
+    root.appendChild(b);
+
+    assert.equal(slot.getDistributedNodes().length, 7);
+    assertArrayEqual(slot.getDistributedNodes(), host.childNodes);
+  });
+
+  test('getDistributedNodes add slot deeper inside tree', function() {
+    var foo = document.createElement('div');
+    var fooRoot = foo.createShadowRoot();
+    fooRoot.innerHTML = '<div>' +
+      ' <div>item1</div> <div>item2</div> <div>item3</div> ' +
+    '</div>';
+
+    var bar = fooRoot.firstChild;
+    var barRoot = bar.createShadowRoot();
+    barRoot.innerHTML = '<div><slot></slot></div>';
+
+    var zot = barRoot.firstChild;
+    var zotRoot = zot.createShadowRoot();
+    zotRoot.innerHTML = '<slot></slot>';
+    var slot = zotRoot.firstChild;
+
+    assert.equal(slot.getDistributedNodes().length, 7);
+    assertArrayEqual(content.getDistributedNodes(), fooRoot.firstChild.childNodes);
+  });
+
+  test('Adding tree with slot again', function() {
+    var host = document.createElement('div');
+    host.innerHTML = ' <p>Content</p> ';
+
+    var t = document.createElement('template');
+    t.innerHTML = ' <div> <div> [<slot></slot>] </div> </div> ';
+
+    var sr = host.createShadowRoot();
+    sr.appendChild(t.content.cloneNode(true));
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML,
+        ' <div> <div> [ <p>Content</p> ] </div> </div> ');
+  });
+
+  test('adding a new slot element to a shadow tree', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a><b slot="b"></b>';
+    var a = host.firstChild;
+    var b = host.lastChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<c></c>';
+    var c = sr.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c></c>');
+
+    var slot = document.createElement('slot');
+    slot.name = 'b';
+    c.appendChild(slot);
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><b slot="b"></b></c>');
+
+    c.removeChild(slot);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c></c>');
+  });
+
+  test('adding a new slot element to a shadow tree 2', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a><b slot="b"></b>';
+    var a = host.firstChild;
+    var b = host.lastChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<c></c>';
+    var c = sr.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c></c>');
+
+    var d = document.createElement('d');
+    var slot = d.appendChild(document.createElement('slot'));
+    slot.name = 'b';
+    c.appendChild(d);
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><d><b slot="b"></b></d></c>');
+
+    c.removeChild(d);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c></c>');
+  });
+
+  test('Mutating slot name', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a slot="a"></a><b slot="b"></b>';
+    var a = host.firstChild;
+    var b = host.lastChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<c><slot name="a"></slot></c>';
+    var c = sr.firstChild;
+    var slot = c.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><a slot="a"></a></c>');
+
+    slot.name = 'b';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><b slot="b"></b></c>');
+
+    slot.name = '';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><a slot="a"></a><b slot="b"></b></c>');
+  });
+
+  test('Mutating slot fallback', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<slot name="x"></slot>';
+    var slot = sr.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '');
+
+    slot.textContent = 'fallback';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback');
+
+    var b = slot.appendChild(document.createElement('b'));
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback<b></b>');
+
+    slot.removeChild(b);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback');
+  });
+
+  test('Mutating slot fallback 2', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<b><slot name="x"></slot></b>';
+    var b = sr.firstChild;
+    var slot = b.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b></b>');
+
+    slot.textContent = 'fallback';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
+
+    var c = slot.appendChild(document.createElement('c'));
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback<c></c></b>');
+
+    slot.removeChild(c);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
+  });
+
+  test('getDistributedNodes outside shadow dom', function() {
+    var content = document.createElement('slot');
+    assert.deepEqual(slot.getDistributedNodes(), []);
+  });
+
+  test('instanceof', function() {
+    assert.instanceOf(document.createElement('slot'), HTMLSlotElement);
+  });
+
+  test('constructor', function() {
+    assert.equal(HTMLSlotElement,
+                 document.createElement('slot').constructor);
+  });
+});


### PR DESCRIPTION
Begins to address #430.

This solution appears to work fine for the polyfill, but slot would still not be supported for browsers that support ShadowDOM but not `<slot>`. I'd be very happy to append this if I could get some guidance on where best to branch the logic.
