### PR TITLE
Fix safari 9 webgl wrappers

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -431,6 +431,7 @@ window.ShadowDOMPolyfill = {};
     });
   }
 
+  scope.addForwardingProperties = addForwardingProperties;
   scope.assert = assert;
   scope.constructorTable = constructorTable;
   scope.defineGetter = defineGetter;

--- a/src/ShadowDOM/wrappers/WebGLRenderingContext.js
+++ b/src/ShadowDOM/wrappers/WebGLRenderingContext.js
@@ -25,7 +25,6 @@
   if (!OriginalWebGLRenderingContext)
     return;
 
-
   function WebGLRenderingContext(impl) {
     setWrapper(impl, this);
   }

--- a/src/ShadowDOM/wrappers/WebGLRenderingContext.js
+++ b/src/ShadowDOM/wrappers/WebGLRenderingContext.js
@@ -11,6 +11,7 @@
 (function(scope) {
   'use strict';
 
+  var addForwardingProperties = scope.addForwardingProperties;
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
   var setWrapper = scope.setWrapper;
@@ -23,6 +24,7 @@
   // IE10 does not have WebGL.
   if (!OriginalWebGLRenderingContext)
     return;
+
 
   function WebGLRenderingContext(impl) {
     setWrapper(impl, this);
@@ -43,6 +45,15 @@
       unsafeUnwrap(this).texSubImage2D.apply(unsafeUnwrap(this), arguments);
     }
   });
+
+  // WebKit has two additional prototypes in the chain for WebGLRenderingContext which are not exposed on `window`: WebGLRenderingContextBase and CanvasRenderingContextBase.
+  // CanvasRenderingContextBase has only one getter `canvas`, which is taken care of already, so we skip it.
+
+  var OriginalWebGLRenderingContextBase = Object.getPrototypeOf(OriginalWebGLRenderingContext.prototype);
+
+  if (OriginalWebGLRenderingContextBase !== Object.prototype) {
+    addForwardingProperties(OriginalWebGLRenderingContextBase, WebGLRenderingContext.prototype);
+  }
 
   // Blink/WebKit has broken DOM bindings. Usually we would create an instance
   // of the object and pass it into registerWrapper as a "blueprint" but

--- a/tests/ShadowDOM/js/HTMLCanvasElement.js
+++ b/tests/ShadowDOM/js/HTMLCanvasElement.js
@@ -113,6 +113,7 @@ suite('HTMLCanvasElement', function() {
     try {
       gl = canvas.getContext('webgl');
     } catch (ex) {
+      console.error(ex);
     }
     // IE10 does not have WebGL.
     // Chrome returns null if the graphics card is not supported


### PR DESCRIPTION
Safari 9 added moved all the good stuff from WebGLRenderingContext to a new
prototype, WebGLRenderingContextBase, which exposed to window.

This change mixes the WebGLRenderingContextBase properties and methods into
WebGLRenderingContext

Fixes #414