### PR TITLE
Remove unused variable from parser.js

### DIFF
--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -255,7 +255,7 @@ var importParser = {
     if (doc && this._mayParse.indexOf(doc) < 0) {
       this._mayParse.push(doc);
       var nodes = doc.querySelectorAll(this.parseSelectorsForNode(doc));
-      for (var i=0, l=nodes.length, p=0, n; (i<l) && (n=nodes[i]); i++) {
+      for (var i=0, l=nodes.length, n; (i<l) && (n=nodes[i]); i++) {
         if (!this.isParsed(n)) {
           if (this.hasResource(n)) {
             return nodeIsImport(n) ? this.nextToParseInDoc(n.__doc, n) : n;


### PR DESCRIPTION
It seems that `p=0` is not used at all