### PR TITLE
Reverts #463: ShadowRoots' activeElement no longer returns elements in light DOM.

### DIFF
--- a/src/ShadowDOM/wrappers/ShadowRoot.js
+++ b/src/ShadowDOM/wrappers/ShadowRoot.js
@@ -80,15 +80,8 @@
 
       var activeElement = wrap(unwrappedActiveElement);
 
-      // If the active element is this ShadowRoot's host, this ShadowRoot
-      // has no active element.
-      if (activeElement === this.host) {
-        return null;
-      }
-
-      // Loop while activeElement is not a shallow descendant of this ShadowRoot
-      // or this ShadowRoot's host.
-      while (!this.contains(activeElement) && !this.host.contains(activeElement)) {
+      // Loop while activeElement is not a shallow child of this ShadowRoot.
+      while (!this.contains(activeElement)) {
         // Iterate until we hit activeElement's containing ShadowRoot (which
         // isn't this one) or document.
         while (activeElement.parentNode) {

--- a/tests/ShadowDOM/html/activeElement.html
+++ b/tests/ShadowDOM/html/activeElement.html
@@ -131,7 +131,7 @@ suite('activeElement', function() {
     r_l.focus();
 
     assert.equal(doc.activeElement, r_l);
-    assert.equal(r.shadowRoot.activeElement, r_l);
+    assert.equal(r.shadowRoot.activeElement, null);
     assert.equal(r_0.shadowRoot.activeElement, null);
     assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
@@ -158,7 +158,7 @@ suite('activeElement', function() {
 
     assert.equal(doc.activeElement, r);
     assert.equal(r.shadowRoot.activeElement, r_0_l);
-    assert.equal(r_0.shadowRoot.activeElement, r_0_l);
+    assert.equal(r_0.shadowRoot.activeElement, null);
     assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
     assert.equal(r_1.shadowRoot.activeElement, null);
@@ -185,7 +185,7 @@ suite('activeElement', function() {
     assert.equal(doc.activeElement, r);
     assert.equal(r.shadowRoot.activeElement, r_0);
     assert.equal(r_0.shadowRoot.activeElement, r_0_0_l);
-    assert.equal(r_0_0.shadowRoot.activeElement, r_0_0_l);
+    assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
     assert.equal(r_1.shadowRoot.activeElement, null);
     assert.equal(r_1_0.shadowRoot.activeElement, null);
@@ -212,7 +212,7 @@ suite('activeElement', function() {
     assert.equal(r.shadowRoot.activeElement, r_0);
     assert.equal(r_0.shadowRoot.activeElement, r_0_1_l);
     assert.equal(r_0_0.shadowRoot.activeElement, null);
-    assert.equal(r_0_1.shadowRoot.activeElement, r_0_1_l);
+    assert.equal(r_0_1.shadowRoot.activeElement, null);
     assert.equal(r_1.shadowRoot.activeElement, null);
     assert.equal(r_1_0.shadowRoot.activeElement, null);
     assert.equal(r_1_1.shadowRoot.activeElement, null);
@@ -239,7 +239,7 @@ suite('activeElement', function() {
     assert.equal(r_0.shadowRoot.activeElement, null);
     assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
-    assert.equal(r_1.shadowRoot.activeElement, r_1_l);
+    assert.equal(r_1.shadowRoot.activeElement, null);
     assert.equal(r_1_0.shadowRoot.activeElement, null);
     assert.equal(r_1_1.shadowRoot.activeElement, null);
   });
@@ -252,7 +252,7 @@ suite('activeElement', function() {
     assert.equal(r_0.shadowRoot.activeElement, null);
     assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
-    assert.equal(r_1.shadowRoot.activeElement, r_1_l);
+    assert.equal(r_1.shadowRoot.activeElement, null);
     assert.equal(r_1_l.shadowRoot.activeElement, r_1_l_0);
     assert.equal(r_1_0.shadowRoot.activeElement, null);
     assert.equal(r_1_1.shadowRoot.activeElement, null);
@@ -266,7 +266,7 @@ suite('activeElement', function() {
     assert.equal(r_0.shadowRoot.activeElement, null);
     assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
-    assert.equal(r_1.shadowRoot.activeElement, r_1_l);
+    assert.equal(r_1.shadowRoot.activeElement, null);
     assert.equal(r_1_l.shadowRoot.activeElement, r_1_l_1);
     assert.equal(r_1_0.shadowRoot.activeElement, null);
     assert.equal(r_1_1.shadowRoot.activeElement, null);
@@ -294,7 +294,7 @@ suite('activeElement', function() {
     assert.equal(r_0_0.shadowRoot.activeElement, null);
     assert.equal(r_0_1.shadowRoot.activeElement, null);
     assert.equal(r_1.shadowRoot.activeElement, r_1_0_l);
-    assert.equal(r_1_0.shadowRoot.activeElement, r_1_0_l);
+    assert.equal(r_1_0.shadowRoot.activeElement, null);
     assert.equal(r_1_1.shadowRoot.activeElement, null);
   });
 
@@ -321,7 +321,7 @@ suite('activeElement', function() {
     assert.equal(r_0_1.shadowRoot.activeElement, null);
     assert.equal(r_1.shadowRoot.activeElement, r_1_1_l);
     assert.equal(r_1_0.shadowRoot.activeElement, null);
-    assert.equal(r_1_1.shadowRoot.activeElement, r_1_1_l);
+    assert.equal(r_1_1.shadowRoot.activeElement, null);
   });
 });
 


### PR DESCRIPTION
See w3c/webcomponents#358.