### PR TITLE
Set HTMLTemplateElement as a window property

### DIFF
--- a/src/Template/Template.js
+++ b/src/Template/Template.js
@@ -225,7 +225,7 @@
   }
 
   if (needsTemplate) {
-    HTMLTemplateElement = TemplateImpl;
+    window.HTMLTemplateElement = TemplateImpl;
   }
 
 })();


### PR DESCRIPTION
Rather than as a global variable, which seems to have troubles with strict mode in a few browsers.

Closes #496