### PR TITLE
Ensures extended element names are case-insensitive during registration

### DIFF
--- a/src/CustomElements/register.js
+++ b/src/CustomElements/register.js
@@ -91,6 +91,10 @@ function register(name, options) {
   }
   // record name
   definition.__name = name.toLowerCase();
+  // ensure extended name is also treated case-insensitively
+  if (definition.extends) {
+    definition.extends = definition.extends.toLowerCase();
+  }
   // ensure a lifecycle object so we don't have to null test it
   definition.lifecycle = definition.lifecycle || {};
   // build a list of ancestral custom elements (for native base detection)

--- a/tests/CustomElements/js/customElements.js
+++ b/tests/CustomElements/js/customElements.js
@@ -183,9 +183,9 @@ suite('customElements', function() {
   });
 
   test('document.registerElement with type extension treats names as case insensitive', function() {
-    var proto = {prototype: Object.create(HTMLButtonElement.prototype), extends: 'button'};
+    var proto = {prototype: Object.create(HTMLButtonElement.prototype), extends: 'butTON'};
     proto.prototype.isXCase = true;
-    var XCase = document.registerElement('X-EXTEND-CASE', proto);
+    var XCase = document.registerElement('X-extend-CASE', proto);
     // createElement
     var x = document.createElement('button', 'X-EXTEND-CASE');
     assert.equal(x.isXCase, true);


### PR DESCRIPTION
Fixes #506 and updates a test case to catch regressions.
