### PR TITLE
Remove the potential risk of client-side ReDoS through ShadowCSS

### DIFF
--- a/src/ShadowCSS/ShadowCSS.js
+++ b/src/ShadowCSS/ShadowCSS.js
@@ -566,7 +566,7 @@ var selectorRe = /([^{]*)({[\s\S]*?})/gim,
     // note: :host-context pre-processed to -shadowcsshostcontext.
     polyfillHostContext = '-shadowcsscontext',
     parenSuffix = ')(?:\\((' +
-        '(?:\\([^)(]*\\)|[^)(]*)+?' +
+        '(?:\\([^)(]*\\)|[^)(])+?' +
         ')\\))?([^,{]*)';
     var cssColonHostRe = new RegExp('(' + polyfillHost + parenSuffix, 'gim'),
     cssColonHostContextRe = new RegExp('(' + polyfillHostContext + parenSuffix, 'gim'),


### PR DESCRIPTION
This patch fixes a client-side ReDoS, a minor security vulnerability, by reducing the computational complexity without losing the mearning of the original regular expression.

#### TL;DR

[ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) is a regular expression denial of service, which consumes exponential computation time by the size of an input string. Similar to other langulates, JavaScript employs a backtracking approach on regular expression matching, in which the regular expression engine reads the input string as many characters as a quantifier (such as `*` and `+`) matches but once the later pattern fails, it backs up a character and recalculates the rest until it succeeds or fails. In the case where quantifiers are nested, the regular expression engine backtracks to try all possible permutations of the regular expression.

ShadowCSS uses regular expressions to convert Web Components CSS expressions to standard ones for browsers that lack native support on Web Components. The `cssColonHostRe` variable at line 571 in ShadowCSS.js contains a regular expression `/(-shadowcsshost)(?:\\(((?:\\([^)(]*\\)|[^)(]*)+?)\\))?([^,{]*)/gim` to find a string like `-shadowcsshost(expression)` but its nested quantifiers having a pattern of `(A|B*)+` makes this regular expression vulnerable to `-shadowcsshost(~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`, for example. Suppose a tilde (`~`) appears 50 times in the sample attack string, the regular expression engine works with the following steps and consumes exponential computation time as a result of failing to find `)` at the end of each step.

1. 50 tildes are read at an iteration. `)` isn't found. Back up.
2. 49 tildes have been already read. The remaining tilde is read. `)` isn't found. Back up.
3. 48 tildes have been already read. The remaining 2 tildes are read. `)` isn't found. Back up.
4. 48 tildes plus a tilde have been already read. The remaining tilde is read. `)` isn't found. Back up.
5. 47 tildes have been already read. The remaining 3 tildes are read. `)` isn't found. Back up.
6. 47 tildes plus 2 tildes have been already read. The remaining tilde is read. `)` isn't found. Back up.
7. 47 tildes plus a tilde have been already read. The remaining 2 tildes are read at once. `)` isn't found. Back up.
8. 47 tildes plus 2 tilde have been already read. The remaining tilde is read. `)` isn't found. Back up.
9. ...

#### Patch

The patch removes the nested quantifier in a regular expression because `(A|B*)+` is equivalent to `(A|B)+`.

#### Proof of Concept

**PoC of vulnerability**

These are the steps to reproduce. I tested this on Firefox 45.0.1.

1. Open https://jsbin.com/giyise with your browser that doesn't have a native support on Web Components. This page contains a Shadow DOM element, and allows a visitor to change the color of texts inside of the Shadow DOM through the location hash by setting `<style>:host{color:' + location.hash.split('#')[1] + '}</style>` in the Shadow DOM element.
2. Click `red` and `green` and make sure the text color inside of the Shadow DOM is changed.
3. Click the `ReDoS` link, which changes the color name to `-shadowcsshost(~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`. If the attack succeeds, your browser will be unable to respond.

**PoC of the fix**

Open https://jsbin.com/jehiyi and follow the same steps in the PoC of vulnerability. This time, your browser will be able to respond.

#### Security Impact

The security impact of this ReDoS is low because attacks can be successful only when a website allows users to control a CSS text, which is rare. Even when the attack is successful, attackers can only annoy users with non-responsive web pages.