### PR TITLE
Keep prefix attribute selectors while shimming

### DIFF
--- a/src/ShadowCSS/ShadowCSS.js
+++ b/src/ShadowCSS/ShadowCSS.js
@@ -586,7 +586,7 @@ var selectorRe = /([^{]*)({[\s\S]*?})/gim,
       /\/shadow\//g, // former ::shadow
       /\/shadow-deep\//g, // former /deep/
       /\^\^/g,     // former /shadow/
-      /\^/g        // former /shadow-deep/
+      /\^(?!=)/g   // former /shadow-deep/
     ];
 
 function stylesToCssText(styles, preserveComments) {


### PR DESCRIPTION
ShadowCSS converts all prefix attribute selectors `[attr^=value]` to exact selectors `[attr=value]`.

The bug was caused due to a bad regular expression which intended to remove `^`. To maintain status quo but fix the issue, I have simply put in a negative look-ahead for `=`.

Fixes #207