### PR TITLE
Do not ignore elements with type="text/css"

### DIFF
--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -35,6 +35,8 @@ var importParser = {
     'link[rel=stylesheet]:not([type])',
     'style:not([type])',
     'script:not([type])',
+    'link[rel=stylesheet][type="text/css"]',
+    'style[type="text/css"]',
     'script[type="application/javascript"]',
     'script[type="text/javascript"]'
   ].join(','),

--- a/tests/HTMLImports/html/imports/sheet5.css
+++ b/tests/HTMLImports/html/imports/sheet5.css
@@ -8,6 +8,6 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-.link-wrong-typed {
-  background-color: navy;
+.link-typed {
+  background-color: green;
 }

--- a/tests/HTMLImports/html/imports/style-elements-import.html
+++ b/tests/HTMLImports/html/imports/style-elements-import.html
@@ -24,7 +24,12 @@
 </style>
 
 <style type="foo">
-    .style-typed {
+    .style-wrong-typed {
         background: red;
+    }
+</style>
+<style type="text/css">
+    .style-typed {
+        background: blue;
     }
 </style>

--- a/tests/HTMLImports/html/imports/style-links-import.html
+++ b/tests/HTMLImports/html/imports/style-links-import.html
@@ -12,3 +12,4 @@
 <link rel="stylesheet" href="sheet2.css">
 
 <link rel="stylesheet" type="foo" href="sheet4.css">
+<link rel="stylesheet" type="text/css" href="sheet5.css">

--- a/tests/HTMLImports/html/style-links.html
+++ b/tests/HTMLImports/html/style-links.html
@@ -36,9 +36,11 @@
   <div class="styled">red?</div>
   <div class="overridden-style">black?</div>
 
+  <div class="link-wrong-typed">red?</div>
   <div class="link-typed">red?</div>
 
-  <div class="style-typed">red?</div>
+  <div class="style-wrong-typed">red?</div>
+  <div class="style-typed">green?</div>
 
 
   <script>
@@ -63,11 +65,13 @@
         // styles in style are applied in the correct order and overriddable
         chai.assert.equal(computedStyle('.overridden-style').backgroundColor, 'rgb(0, 0, 0)');
         if (!HTMLImports.useNative) {
-          // links with type attr are not imported
-          chai.assert.notEqual(computedStyle('.link-typed').backgroundColor, 'rgb(0, 0, 128)');
+          // links with type attr != text/css are not imported
+          chai.assert.equal(computedStyle('.link-typed').backgroundColor, 'rgb(0, 128, 0)');
+          chai.assert.notEqual(computedStyle('.link-wrong-typed').backgroundColor, 'rgb(0, 0, 128)');
         }
-        // styles with type attr are not imported
-        chai.assert.notEqual(computedStyle('.style-typed').backgroundColor, 'rgb(255, 0, 0)');
+        // styles with type attr != text/css are not imported
+        chai.assert.equal(computedStyle('.style-typed').backgroundColor, 'rgb(0, 0, 255)');
+        chai.assert.notEqual(computedStyle('.style-wrong-typed').backgroundColor, 'rgb(255, 0, 0)');
 
         done();
       });


### PR DESCRIPTION
Fixes #400.

Currently `<link rel="stylesheet" type="text/css" ...>` and `<style type="text/css">` are being ignored by the HTMLImports parser despite them being valid.

Also adds test cases.
