### PR TITLE
NPM support.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+/*
+!/dist
+!/CONTRIBUTING.md
+!/LICENSE.md
+!/README.md
+!/package.json

--- a/externs/html5.js
+++ b/externs/html5.js
@@ -1,0 +1,1 @@
+MutationObserver.prototype.takeRecords = function() {};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,17 +12,19 @@
 
 'use strict';
 
-var
-  audit = require('gulp-audit'),
-  concat = require('gulp-concat'),
-  exec = require('child_process').exec,
-  fs = require('fs'),
-  gulp = require('gulp'),
-  header = require('gulp-header'),
-  path = require('path'),
-  runseq = require('run-sequence'),
-  uglify = require('gulp-uglify')
-;
+var audit = require('gulp-audit');
+var compilerPackage = require('google-closure-compiler');
+var concat = require('gulp-concat');
+var exec = require('child_process').exec;
+var fs = require('fs');
+var gulp = require('gulp');
+var header = require('gulp-header');
+var path = require('path');
+var rename = require('gulp-rename');
+var runseq = require('run-sequence');
+var uglify = require('gulp-uglify');
+
+var closureCompiler = compilerPackage.gulp();
 
 // init tests with gulp
 require('web-component-tester').gulp.init(gulp);
@@ -129,7 +131,21 @@ defineBuildTask('HTMLImports');
 defineBuildTask('ShadowDOM');
 defineBuildTask('MutationObserver');
 
-gulp.task('build', ['webcomponents', 'webcomponents-lite', 'CustomElements', 
+gulp.task('CustomElementsV1', function () {
+  return gulp.src('./src/CustomElements/v1/CustomElements.js', {base: './'})
+      .pipe(closureCompiler({
+          compilation_level: 'ADVANCED',
+          warning_level: 'VERBOSE',
+          language_in: 'ECMASCRIPT6_STRICT',
+          language_out: 'ECMASCRIPT5_STRICT',
+          output_wrapper: '(function(){\n%output%\n}).call(this)',
+          externs: 'externs/html5.js',
+          js_output_file: 'CustomElementsV1.min.js'
+        }))
+      .pipe(gulp.dest('./dist'));
+});
+
+gulp.task('build', ['webcomponents', 'webcomponents-lite', 'CustomElements',
   'HTMLImports', 'ShadowDOM', 'copy-bower', 'MutationObserver']);
 
 gulp.task('release', function(cb) {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   },
   "homepage": "http://webcomponents.org",
   "devDependencies": {
+    "google-closure-compiler": "^20160208.7.0",
     "gulp": "^3.8.8",
     "gulp-audit": "^1.0.0",
     "gulp-concat": "^2.4.1",
     "gulp-header": "^1.1.1",
+    "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.0.1",
     "run-sequence": "^1.0.1",
     "web-component-tester": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webcomponents.js",
   "version": "0.7.21",
   "description": "webcomponents.js",
-  "main": "webcomponents.js",
+  "main": "dist/webcomponents.js",
   "directories": {
     "test": "tests"
   },
@@ -16,7 +16,8 @@
     "url": "https://github.com/webcomponents/webcomponentsjs/issues"
   },
   "scripts": {
-    "test": "wct"
+    "test": "wct",
+    "prepublish": "gulp build"
   },
   "homepage": "http://webcomponents.org",
   "devDependencies": {

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -143,9 +143,8 @@
       this._definitions.set(localName, definition);
 
       // 5.1.22
-      // The spec says we should upgrade all existing elements now, but if we
-      // defer we can do less tree walks
-      // scheduleUpgrade();
+      // this causes an upgrade of the document
+      this._addNodes(document.childNodes);
     },
 
     flush() {

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
  * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -81,62 +81,56 @@ var CustomElementDefinition;
     }
 
     define(name, constructor, options) {
-      // 5.1.1
+      // 2.4.1
       if (typeof constructor !== 'function') {
         throw new TypeError('constructor must be a Constructor');
       }
 
-      // 5.1.2
+      // 2.4.2
       name = name.toString().toLowerCase();
 
-      // 5.1.3
+      // 2.4.3
       if (!customNameValidation.test(name)) {
-        throw new Error(`NotSupportedError: document.defineElement failed for '${name}'. The element name is not valid.`);
+        throw new SyntaxError(`CustomElementRegistry.define: The element name '${name}' is not valid.`);
       }
       if (isReservedTag(name)) {
-        throw new Error(`NotSupportedError: document.defineElement failed for '${name}'. The element name is reserved.`);
+        throw new SyntaxError(`CustomElementRegistry.define: The element name '${name}' is reserved.`);
       }
 
-      // 5.1.4? Can't polyfill?
-
-      // 5.1.5
+      // 2.4.4
       if (this._definitions.has(name)) {
-        throw new Error(`NotSupportedError: document.defineElement an element with name '${name}' is already registered`);
+        throw new Error(`NotSupportedError: CustomElementRegistry.define: An element with name '${name}' is already defined`);
       }
 
-      // 5.1.6
-      // IE11 doesn't support Map.values, only Map.forEach
+      // 2.4.5
       if (this._constructors.has(constructor)) {
-        throw new Error(`NotSupportedError: document.defineElement failed for '${name}'. The constructor is already used.`);
+        throw new Error(`NotSupportedError: CustomElementRegistry.define failed for '${name}'. The constructor is already used.`);
       }
 
-      // 5.1.7
+      // 2.4.6
       var localName = name;
 
-      // 5.1.8
-      var _extends = options && options.extends || '';
+      // 2.4.7 & 2.4.8: not supporting extends
 
-      // 5.1.9
-      // skip for now
-      // if (_extends !== null) {
-      // }
-
-      // 5.1.10, 5.1.11
+      // 2.4.9, 2.4.10
       var observedAttributes = constructor['observedAttributes'] || [];
 
-      // 5.1.12
+      // 2.4.11
       var prototype = constructor.prototype;
 
-      // 5.1.13?
+      // 2.4.12
+      if (typeof prototype !== 'object') {
+        throw new TypeError('CustomElementRegistry.define: type of prototype is not "object"');
+      }
 
-      // 5.1.14 & 5.1.15
+      // 2.4.13 & 2.4.14
       var connectedCallback = getCallback(prototype, 'connectedCallback', localName);
-      // 5.1.16 & 5.1.17
+      // 2.4.15 & 2.4.16
       var disconnectedCallback = getCallback(prototype, 'disconnectedCallback', localName);
-      // 5.1.18 & 5.1.19
+      // 2.4.17 & 2.4.18
       var attributeChangedCallback = getCallback(prototype, 'attributeChangedCallback', localName);
 
-      // 5.1.20
+      // 2.4.19
       // @type {CustomElementDefinition}
       var definition = {
         name: name,
@@ -148,11 +142,10 @@ var CustomElementDefinition;
         observedAttributes: observedAttributes,
       };
 
-      // 5.1.21
+      // 2.4.20
       this._definitions.set(localName, definition);
       this._constructors.set(constructor, localName);
 
-      // 5.1.22
       // this causes an upgrade of the document
       this._addNodes(doc.childNodes);
     }
@@ -296,12 +289,7 @@ var CustomElementDefinition;
     throw new Error('unknown constructor. Did you call customElements.define()?');
   }
   HTMLElement.prototype = Object.create(origHTMLElement.prototype);
-  Object.defineProperty(HTMLElement.prototype, 'constructor', {
-    writable: false,
-    configurable: true,
-    enumerable: false,
-    value: HTMLElement,
-  });
+  Object.defineProperty(HTMLElement.prototype, 'constructor', {value: HTMLElement});
 
   // patch doc.createElement
 

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * 2.3
+ * http://w3c.github.io/webcomponents/spec/custom/#dfn-element-definition
+ *
+ * @typedef {Object} Definition
+ * @property {Function} name
+ * @property {Function} localName
+ * @property {Function} constructor
+ * @property {Function} attachedCallback
+ * @property {Function} detachedCallback
+ * @property {Function} attributeChangedCallback
+ * @property {String[]} observedAttributes
+ * http://w3c.github.io/webcomponents/spec/custom/#dfn-element-definition-construction-stack
+ * @property {Function[]} constructionStack
+ */
+
+(function() {
+  'use strict';
+
+  window.CustomElements = {};
+
+  var _newInstance;
+  var _newTagName;
+
+  CustomElements.setCurrentTag = function(tagName) {
+    _newTagName = _newTagName || tagName;
+  }
+
+  function setNewInstance(instance) {
+    console.assert(_newInstance == null);
+    _newInstance = instance;
+  }
+
+  var origHTMLElement = HTMLElement;
+
+  // TODO: patch up all built-in subclasses of HTMLElement to use the fake
+  // HTMLElement.prototype
+  window.HTMLElement = function() {
+    if (_newInstance) {
+      var i = _newInstance;
+      _newInstance = null;
+      _newTagName = null;
+      return i;
+    }
+    if (_newTagName) {
+      var tagName = _newTagName;
+      _newTagName = null;
+      return document.createElement(tagName);
+    }
+    throw new Error('unknown constructor');
+  }
+  HTMLElement.prototype = Object.create(origHTMLElement.prototype);
+  Object.defineProperty(HTMLElement.prototype, 'constructor', {
+    writable: false,
+    configurable: true,
+    enumerable: false,
+    value: HTMLElement,
+  });
+
+  // @type {Map<String, Definition>}
+  var registry = new Map();
+
+  var reservedTagList = [
+    'annotation-xml',
+    'color-profile',
+    'font-face',
+    'font-face-src',
+    'font-face-uri',
+    'font-face-format',
+    'font-face-name',
+    'missing-glyph',
+  ];
+  var customNameValidation = /^[a-z][.0-9_a-z]*-[\-.0-9_a-z]*$/;
+
+  var microtaskScheduler = Promise.resolve();
+
+  var upgradeTask = null;
+
+  function scheduleMicrotask(task) {
+    return microtaskScheduler.then(task);
+  }
+
+  document.defineElement = function(name, constructor, options) {
+    // 5.1.1
+    if (typeof constructor !== 'function') {
+      throw new TypeError('constructor must be a Constructor');
+    }
+
+    // 5.1.2
+    name = name.toString().toLowerCase();
+
+    // 5.1.3
+    if (!customNameValidation.test(name)) {
+      throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is not valid.`);
+    }
+    if (isReservedTag(name)) {
+      throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is reserved.`);
+    }
+
+    // 5.1.4? Can't polyfill?
+
+    // 5.1.5
+    if (registry.has(name)) {
+      throw new Error(`NotSupportedError: Document.defineElement an element with name '${name}' is already registered`);
+    }
+
+    // 5.1.6
+    // IE11 doesn't support Map.values, only Map.forEach
+    registry.forEach(function(value, key) {
+      if (value.constructor === constructor) {
+        throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The constructor is already used.`);
+      }
+    });
+
+    // 5.1.7
+    var localName = name;
+
+    // 5.1.8
+    var _extends = options && options.extends || '';
+
+    // 5.1.9
+    if (_extends !== null) {
+      // skip for now
+    }
+
+    // 5.1.10, 5.1.11
+    var observedAttributes = constructor.observedAttributes || [];
+
+    // 5.1.12
+    var prototype = constructor.prototype;
+
+    // 5.1.13?
+
+    // 5.1.14
+    var attachedCallback = prototype.attachedCallback;
+    // 5.1.15
+    checkCallback(attachedCallback);
+    // 5.1.16
+    var detachedCallback = prototype.detachedCallback;
+    // 5.1.17
+    checkCallback(detachedCallback);
+    // 5.1.18
+    var attributeChangedCallback = prototype.attributeChangedCallback;
+    // 5.1.19
+    checkCallback(attributeChangedCallback);
+
+    // 5.1.20
+    // @type {Definition}
+    var definition = {
+      name: name,
+      localName: localName,
+      constructor: constructor,
+      attachedCallback: attachedCallback,
+      detachedCallback: detachedCallback,
+      attributeChangedCallback: attributeChangedCallback,
+    };
+
+    // 5.1.21
+    registry.set(localName, definition);
+
+    // 5.1.22
+    // The spec says we should upgrade all existing elements now, but if we
+    // defer we can do less tree walks
+    scheduleUpgrade();
+  }
+
+  var _origCreateElement = document.createElement;
+  document.createElement = function(tagName) {
+    var instance = _origCreateElement.call(document, tagName);
+    var registration = registry.get(tagName);
+    if (registration) {
+      var prototype = registration.constructor.prototype;
+      Object.setPrototypeOf(instance, prototype);
+      setNewInstance(instance);
+      new (registration.constructor)();
+      console.assert(_newInstance == null);
+    }
+    return instance;
+  };
+
+  function scheduleUpgrade() {
+    if (upgradeTask !== null) {
+      return
+    }
+    upgradeTask = scheduleMicrotask(upgrade);
+  }
+
+  function upgrade() {
+    _upgrade(document.documentElement);
+  }
+
+  function _upgrade(element) {
+    if (element.tagName === 'LINK' && element.import) {
+      _upgrade(element.import.documentElement);
+    } else {
+      var children = element.children;
+      if (element.shadowRoot) {
+        children = children.concat(element.shadowRoot.children);
+      }
+      for (var i = 0; i < children.length; i++) {
+        _upgrade(children[i]);
+      }
+    }
+  }
+
+  function checkCallback(callback, elementName, calllbackName) {
+    if (callback !== undefined && !typeof callback !== 'function') {
+      throw new Error(`TypeError: ${elementName} '$[calllbackName]' is not a Function`);
+    }
+  }
+
+  function isReservedTag(name) {
+    return reservedTagList.indexOf(name) !== -1;
+  }
+})();

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -26,6 +26,9 @@ var CustomElementDefinition;
 (function() {
   'use strict';
 
+  var doc = document;
+  var win = window;
+
   /**
    * @const
    * @type {Array<string>}
@@ -46,10 +49,12 @@ var CustomElementDefinition;
    */
   var customNameValidation = /^[a-z][.0-9_a-z]*-[\-.0-9_a-z]*$/;
 
-  function checkCallback(callback, elementName, calllbackName) {
+  function getCallback(proto, calllbackName, elementName) {
+    var callback = proto[calllbackName];
     if (callback !== undefined && typeof callback !== 'function') {
       throw new Error(`TypeError: ${elementName} '${calllbackName}' is not a Function`);
     }
+    return callback;
   }
 
   function isReservedTag(name) {
@@ -88,24 +93,24 @@ var CustomElementDefinition;
 
       // 5.1.3
       if (!customNameValidation.test(name)) {
-        throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is not valid.`);
+        throw new Error(`NotSupportedError: document.defineElement failed for '${name}'. The element name is not valid.`);
       }
       if (isReservedTag(name)) {
-        throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is reserved.`);
+        throw new Error(`NotSupportedError: document.defineElement failed for '${name}'. The element name is reserved.`);
       }
 
       // 5.1.4? Can't polyfill?
 
       // 5.1.5
       if (this._definitions.has(name)) {
-        throw new Error(`NotSupportedError: Document.defineElement an element with name '${name}' is already registered`);
+        throw new Error(`NotSupportedError: document.defineElement an element with name '${name}' is already registered`);
       }
 
       // 5.1.6
       // IE11 doesn't support Map.values, only Map.forEach
       this._definitions.forEach(function(value, key) {
         if (value.constructor === constructor) {
-          throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The constructor is already used.`);
+          throw new Error(`NotSupportedError: document.defineElement failed for '${name}'. The constructor is already used.`);
         }
       });
 
@@ -128,18 +133,12 @@ var CustomElementDefinition;
 
       // 5.1.13?
 
-      // 5.1.14
-      var connectedCallback = prototype['connectedCallback'];
-      // 5.1.15
-      checkCallback(connectedCallback, localName, 'connectedCallback');
-      // 5.1.16
-      var disconnectedCallback = prototype['disconnectedCallback'];
-      // 5.1.17
-      checkCallback(disconnectedCallback, localName, 'disconnectedCallback');
-      // 5.1.18
-      var attributeChangedCallback = prototype['attributeChangedCallback'];
-      // 5.1.19
-      checkCallback(attributeChangedCallback, localName, 'attributeChangedCallback');
+      // 5.1.14 & 5.1.15
+      var connectedCallback = getCallback(prototype, 'connectedCallback', localName);
+      // 5.1.16 & 5.1.17
+      var disconnectedCallback = getCallback(prototype, 'disconnectedCallback', localName);
+      // 5.1.18 & 5.1.19
+      var attributeChangedCallback = getCallback(prototype, 'attributeChangedCallback', localName);
 
       // 5.1.20
       // @type {CustomElementDefinition}
@@ -158,7 +157,7 @@ var CustomElementDefinition;
 
       // 5.1.22
       // this causes an upgrade of the document
-      this._addNodes(document.childNodes);
+      this._addNodes(doc.childNodes);
     },
 
     flush() {
@@ -198,7 +197,7 @@ var CustomElementDefinition;
     _addNodes(nodeList) {
       for (var i = 0; i < nodeList.length; i++) {
         var root = nodeList[i];
-        var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+        var walker = doc.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
         do {
           var node = /** @type {HTMLElement} */ (walker.currentNode);
           var definition = this._definitions.get(node.localName);
@@ -224,7 +223,7 @@ var CustomElementDefinition;
     _removeNodes(nodeList) {
       for (var i = 0; i < nodeList.length; i++) {
         var root = nodeList[i];
-        var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+        var walker = doc.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
         do {
           var node = walker.currentNode;
           if (node.__upgraded && node.__attached) {
@@ -289,18 +288,19 @@ var CustomElementDefinition;
 
   // TODO: patch up all built-in subclasses of HTMLElement to use the fake
   // HTMLElement.prototype
-  var origHTMLElement = window.HTMLElement;
-  window.HTMLElement = function() {
-    if (window['customElements']._newInstance) {
-      var i = window['customElements']._newInstance;
-      window['customElements']._newInstance = null;
-      window['customElements']._newTagName = null;
+  var origHTMLElement = win.HTMLElement;
+  win.HTMLElement = function() {
+    var customElements = win['customElements'];
+    if (customElements._newInstance) {
+      var i = customElements._newInstance;
+      customElements._newInstance = null;
+      customElements._newTagName = null;
       return i;
     }
-    if (window['customElements']._newTagName) {
-      var tagName = window['customElements']._newTagName.toLowerCase();
-      window['customElements']._newTagName = null;
-      return window.document._createElement(tagName, false);
+    if (customElements._newTagName) {
+      var tagName = customElements._newTagName.toLowerCase();
+      customElements._newTagName = null;
+      return doc._createElement(tagName, false);
     }
     throw new Error('unknown constructor');
   }
@@ -312,33 +312,34 @@ var CustomElementDefinition;
     value: HTMLElement,
   });
 
-  // patch document.createElement
+  // patch doc.createElement
 
-  var rawCreateElement = document.createElement.bind(document);
-  document._createElement = function(tagName, callConstructor) {
+  var rawCreateElement = doc.createElement.bind(document);
+  doc._createElement = function(tagName, callConstructor) {
+    var customElements = win['customElements'];
     var element = rawCreateElement.call(document, tagName);
-    var definition = window['customElements']._definitions.get(tagName.toLowerCase());
+    var definition = customElements._definitions.get(tagName.toLowerCase());
     if (definition) {
-      window['customElements']._upgradeElement(element, definition, callConstructor);
+      customElements._upgradeElement(element, definition, callConstructor);
     }
     return element;
   };
-  document.createElement = function(tagName) {
-    return document._createElement(tagName, true);
+  doc.createElement = function(tagName) {
+    return doc._createElement(tagName, true);
   }
 
-  // patch document.createElementNS
+  // patch doc.createElementNS
 
   var HTMLNS = 'http://www.w3.org/1999/xhtml';
-  var _origCreateElementNS = document.createElementNS;
-  document.createElementNS = function(namespaceURI, qualifiedName) {
+  var _origCreateElementNS = doc.createElementNS;
+  doc.createElementNS = function(namespaceURI, qualifiedName) {
     if (namespaceURI === 'http://www.w3.org/1999/xhtml') {
-      return document.createElement(qualifiedName);
+      return doc.createElement(qualifiedName);
     } else {
       return _origCreateElementNS.call(document, namespaceURI, qualifiedName);
     }
   };
 
   /** @type {CustomElementsRegistry} */
-  window['customElements'] = new (window['CustomElementsRegistry'])();
+  window['customElements'] = new CustomElementsRegistry();
 })();

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -16,8 +16,8 @@
  * @property {Function} name
  * @property {Function} localName
  * @property {Function} constructor
- * @property {Function} attachedCallback
- * @property {Function} detachedCallback
+ * @property {Function} connectedCallback
+ * @property {Function} disconnectedCallback
  * @property {Function} attributeChangedCallback
  * @property {String[]} observedAttributes
  * http://w3c.github.io/webcomponents/spec/custom/#dfn-element-definition-construction-stack
@@ -82,13 +82,13 @@
     // 5.1.13?
 
     // 5.1.14
-    var attachedCallback = prototype.attachedCallback;
+    var connectedCallback = prototype.connectedCallback;
     // 5.1.15
-    checkCallback(attachedCallback, localName, 'attachedCallback');
+    checkCallback(connectedCallback, localName, 'connectedCallback');
     // 5.1.16
-    var detachedCallback = prototype.detachedCallback;
+    var disconnectedCallback = prototype.disconnectedCallback;
     // 5.1.17
-    checkCallback(detachedCallback, localName, 'detachedCallback');
+    checkCallback(disconnectedCallback, localName, 'disconnectedCallback');
     // 5.1.18
     var attributeChangedCallback = prototype.attributeChangedCallback;
     // 5.1.19
@@ -100,8 +100,8 @@
       name: name,
       localName: localName,
       constructor: constructor,
-      attachedCallback: attachedCallback,
-      detachedCallback: detachedCallback,
+      connectedCallback: connectedCallback,
+      disconnectedCallback: disconnectedCallback,
       attributeChangedCallback: attributeChangedCallback,
       observedAttributes: observedAttributes,
     };
@@ -316,8 +316,8 @@
         if (node.__upgraded && !node.__attached) {
           node.__attached = true;
           var definition = registry.get(node.localName);
-          if (definition && definition.attachedCallback) {
-            definition.attachedCallback.call(node);
+          if (definition && definition.connectedCallback) {
+            definition.connectedCallback.call(node);
           }
         }
       } while (walker.nextNode())
@@ -333,8 +333,8 @@
         if (node.__upgraded && node.__attached) {
           node.__attached = false;
           var definition = registry.get(node.localName);
-          if (definition && definition.detachedCallback) {
-            definition.detachedCallback.call(node);
+          if (definition && definition.disconnectedCallback) {
+            definition.disconnectedCallback.call(node);
           }
         }
       } while (walker.nextNode())

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -27,176 +27,6 @@
 (function() {
   'use strict';
 
-  window.CustomElements = {};
-
-  function CustomElementsRegistry() {}
-  CustomElementsRegistry.prototype.define = function(name, constructor, options) {
-    // 5.1.1
-    if (typeof constructor !== 'function') {
-      throw new TypeError('constructor must be a Constructor');
-    }
-
-    // 5.1.2
-    name = name.toString().toLowerCase();
-
-    // 5.1.3
-    if (!customNameValidation.test(name)) {
-      throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is not valid.`);
-    }
-    if (isReservedTag(name)) {
-      throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is reserved.`);
-    }
-
-    // 5.1.4? Can't polyfill?
-
-    // 5.1.5
-    if (registry.has(name)) {
-      throw new Error(`NotSupportedError: Document.defineElement an element with name '${name}' is already registered`);
-    }
-
-    // 5.1.6
-    // IE11 doesn't support Map.values, only Map.forEach
-    registry.forEach(function(value, key) {
-      if (value.constructor === constructor) {
-        throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The constructor is already used.`);
-      }
-    });
-
-    // 5.1.7
-    var localName = name;
-
-    // 5.1.8
-    var _extends = options && options.extends || '';
-
-    // 5.1.9
-    if (_extends !== null) {
-      // skip for now
-    }
-
-    // 5.1.10, 5.1.11
-    var observedAttributes = constructor.observedAttributes || [];
-
-    // 5.1.12
-    var prototype = constructor.prototype;
-
-    // 5.1.13?
-
-    // 5.1.14
-    var connectedCallback = prototype.connectedCallback;
-    // 5.1.15
-    checkCallback(connectedCallback, localName, 'connectedCallback');
-    // 5.1.16
-    var disconnectedCallback = prototype.disconnectedCallback;
-    // 5.1.17
-    checkCallback(disconnectedCallback, localName, 'disconnectedCallback');
-    // 5.1.18
-    var attributeChangedCallback = prototype.attributeChangedCallback;
-    // 5.1.19
-    checkCallback(attributeChangedCallback, localName, 'attributeChangedCallback');
-
-    // 5.1.20
-    // @type {Definition}
-    var definition = {
-      name: name,
-      localName: localName,
-      constructor: constructor,
-      connectedCallback: connectedCallback,
-      disconnectedCallback: disconnectedCallback,
-      attributeChangedCallback: attributeChangedCallback,
-      observedAttributes: observedAttributes,
-    };
-
-    // 5.1.21
-    registry.set(localName, definition);
-
-    // 5.1.22
-    // The spec says we should upgrade all existing elements now, but if we
-    // defer we can do less tree walks
-    scheduleUpgrade();
-  };
-
-  window.customElements = new CustomElementsRegistry();
-
-  function observeRoot(root) {
-    if (!root.__observer) {
-      var observer = new MutationObserver(handleMutations);
-      observer.observe(root, {childList: true, subtree: true});
-      root.__observer = observer;
-    }
-    return root.__observer;
-  }
-  var _observer = observeRoot(document);
-
-  CustomElements.flush = function() {
-    handleMutations(_observer.takeRecords());
-  };
-
-  var _newInstance;
-  var _newTagName;
-
-  CustomElements.setCurrentTag = function(tagName) {
-    _newTagName = _newTagName || tagName;
-  }
-
-  function setNewInstance(instance) {
-    console.assert(_newInstance == null);
-    _newInstance = instance;
-  }
-
-  var origHTMLElement = HTMLElement;
-
-  // TODO: patch up all built-in subclasses of HTMLElement to use the fake
-  // HTMLElement.prototype
-  window.HTMLElement = function() {
-    if (_newInstance) {
-      var i = _newInstance;
-      _newInstance = null;
-      _newTagName = null;
-      return i;
-    }
-    if (_newTagName) {
-      var tagName = _newTagName.toLowerCase();
-      _newTagName = null;
-      var element = rawCreateElement(tagName);
-      var definition = registry.get(tagName);
-      if (definition) {
-        _upgradeElement(element, definition, false);
-        return element;
-      }
-    }
-    throw new Error('unknown constructor');
-  }
-  HTMLElement.prototype = Object.create(origHTMLElement.prototype);
-  Object.defineProperty(HTMLElement.prototype, 'constructor', {
-    writable: false,
-    configurable: true,
-    enumerable: false,
-    value: HTMLElement,
-  });
-
-  var rawCreateElement = document.createElement.bind(document);
-  document.createElement = function(tagName) {
-    var element = rawCreateElement(tagName);
-    var definition = registry.get(tagName.toLowerCase());
-    if (definition) {
-      _upgradeElement(element, definition, true);
-    }
-    return element;
-  };
-
-  var HTMLNS = 'http://www.w3.org/1999/xhtml';
-  var _origCreateElementNS = document.createElementNS;
-  document.createElementNS = function(namespaceURI, qualifiedName) {
-    if (namespaceURI === 'http://www.w3.org/1999/xhtml') {
-      return document.createElement(qualifiedName);
-    } else {
-      return _origCreateElementNS(namespaceURI, qualifiedName);
-    }
-  };
-
-  // @type {Map<String, Definition>}
-  var registry = new Map();
-
   var reservedTagList = [
     'annotation-xml',
     'color-profile',
@@ -207,74 +37,8 @@
     'font-face-name',
     'missing-glyph',
   ];
+
   var customNameValidation = /^[a-z][.0-9_a-z]*-[\-.0-9_a-z]*$/;
-
-  var microtaskScheduler = Promise.resolve();
-
-  var upgradeTask = null;
-
-  function scheduleMicrotask(task) {
-    return microtaskScheduler.then(task);
-  }
-
-  function scheduleUpgrade() {
-    if (upgradeTask !== null) {
-      return
-    }
-    upgradeTask = scheduleMicrotask(upgrade);
-  }
-
-  function upgrade() {
-    _upgrade(document.documentElement);
-  }
-
-  function _upgrade(element) {
-    if (element.tagName === 'LINK' && element.import) {
-      _upgrade(element.import.documentElement);
-    } else {
-      var children = element.children;
-      if (element.shadowRoot) {
-        children = children.concat(element.shadowRoot.children);
-      }
-      for (var i = 0; i < children.length; i++) {
-        _upgrade(children[i]);
-      }
-    }
-  }
-
-  var attributeObserver = new MutationObserver(handleAttributeChange);
-  function handleAttributeChange(mutations) {
-    console.log('handleAttributeChange', arguments);
-    for (var i = 0; i < mutations.length; i++) {
-      var mutation = mutations[i];
-      if (mutation.type === 'attributes') {
-        var name = mutation.attributeName;
-        var oldValue = mutation.oldValue;
-        var target = mutation.target;
-        var newValue = target.getAttribute(name);
-        var namespace = mutation.attributeNamespace;
-        target.attributeChangedCallback(name, oldValue, newValue, namespace);
-      }
-    }
-  }
-
-  function _upgradeElement(element, definition, callConstructor) {
-    var prototype = definition.constructor.prototype;
-    Object.setPrototypeOf(element, prototype);
-    if (callConstructor) {
-      setNewInstance(element);
-      element.__upgraded = true;
-      new (definition.constructor)();
-      console.assert(_newInstance == null);
-    }
-    if (definition.attributeChangedCallback && definition.observedAttributes.length > 0) {
-      attributeObserver.observe(element, {
-        attributes: true,
-        attributeOldValue: true,
-        attributeFilter: definition.observedAttributes,
-      });
-    }
-  }
 
   function checkCallback(callback, elementName, calllbackName) {
     if (callback !== undefined && typeof callback !== 'function') {
@@ -287,70 +51,267 @@
     return reservedTagList.indexOf(name) !== -1;
   }
 
-  var forEach = Array.prototype.forEach.call.bind(Array.prototype.forEach);
+  function CustomElementsRegistry() {
+    // @type {Map<String, Definition>}
+    this._definitions = new Map();
+    this._observer = this._observeRoot(document);
+    this._attributeObserver =
+        new MutationObserver(this._handleAttributeChange.bind(this));
+    this._newInstance;
+    this._newTagName;
+    this.polyfilled = true;
+  }
 
-  function handleMutations(mutations) {
-    // console.log('handleMutations', mutations);
-    for (var i = 0; i < mutations.length; i++) {
-      var mutation = mutations[i];
-      if (mutation.type === 'childList') {
-        addNodes(mutation.addedNodes);
-        removeNodes(mutation.removedNodes);
+  CustomElementsRegistry.prototype = {
+    define(name, constructor, options) {
+      // 5.1.1
+      if (typeof constructor !== 'function') {
+        throw new TypeError('constructor must be a Constructor');
       }
-    }
-  }
 
-  function addNodes(nodeList) {
-    for (var i = 0; i < nodeList.length; i++) {
-      var root = nodeList[i];
-      var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
-      do {
-        var node = walker.currentNode;
-        var definition = registry.get(node.localName);
-        if (!definition) {
-          continue;
-        }
-        if (!node.__upgraded) {
-          _upgradeElement(node, definition, true);
-        }
-        if (node.__upgraded && !node.__attached) {
-          node.__attached = true;
-          var definition = registry.get(node.localName);
-          if (definition && definition.connectedCallback) {
-            definition.connectedCallback.call(node);
-          }
-        }
-      } while (walker.nextNode())
-    }
-  }
+      // 5.1.2
+      name = name.toString().toLowerCase();
 
-  function removeNodes(nodeList) {
-    for (var i = 0; i < nodeList.length; i++) {
-      var root = nodeList[i];
-      var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
-      do {
-        var node = walker.currentNode;
-        if (node.__upgraded && node.__attached) {
-          node.__attached = false;
-          var definition = registry.get(node.localName);
-          if (definition && definition.disconnectedCallback) {
-            definition.disconnectedCallback.call(node);
-          }
-        }
-      } while (walker.nextNode())
-    }
-  }
-
-  // recurse up the tree to check if an element is actually in the main document.
-  function inDocument(element) {
-    var p = element;
-    // var doc = window.wrap(document);
-    var doc = document;
-    while (p = p.parentNode || ((p.nodeType === Node.DOCUMENT_FRAGMENT_NODE) && p.host)) {
-      if (p === doc) {
-        return true;
+      // 5.1.3
+      if (!customNameValidation.test(name)) {
+        throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is not valid.`);
       }
+      if (isReservedTag(name)) {
+        throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The element name is reserved.`);
+      }
+
+      // 5.1.4? Can't polyfill?
+
+      // 5.1.5
+      if (this._definitions.has(name)) {
+        throw new Error(`NotSupportedError: Document.defineElement an element with name '${name}' is already registered`);
+      }
+
+      // 5.1.6
+      // IE11 doesn't support Map.values, only Map.forEach
+      this._definitions.forEach(function(value, key) {
+        if (value.constructor === constructor) {
+          throw new Error(`NotSupportedError: Document.defineElement failed for '${name}'. The constructor is already used.`);
+        }
+      });
+
+      // 5.1.7
+      var localName = name;
+
+      // 5.1.8
+      var _extends = options && options.extends || '';
+
+      // 5.1.9
+      if (_extends !== null) {
+        // skip for now
+      }
+
+      // 5.1.10, 5.1.11
+      var observedAttributes = constructor.observedAttributes || [];
+
+      // 5.1.12
+      var prototype = constructor.prototype;
+
+      // 5.1.13?
+
+      // 5.1.14
+      var connectedCallback = prototype.connectedCallback;
+      // 5.1.15
+      checkCallback(connectedCallback, localName, 'connectedCallback');
+      // 5.1.16
+      var disconnectedCallback = prototype.disconnectedCallback;
+      // 5.1.17
+      checkCallback(disconnectedCallback, localName, 'disconnectedCallback');
+      // 5.1.18
+      var attributeChangedCallback = prototype.attributeChangedCallback;
+      // 5.1.19
+      checkCallback(attributeChangedCallback, localName, 'attributeChangedCallback');
+
+      // 5.1.20
+      // @type {Definition}
+      var definition = {
+        name: name,
+        localName: localName,
+        constructor: constructor,
+        connectedCallback: connectedCallback,
+        disconnectedCallback: disconnectedCallback,
+        attributeChangedCallback: attributeChangedCallback,
+        observedAttributes: observedAttributes,
+      };
+
+      // 5.1.21
+      this._definitions.set(localName, definition);
+
+      // 5.1.22
+      // The spec says we should upgrade all existing elements now, but if we
+      // defer we can do less tree walks
+      // scheduleUpgrade();
+    },
+
+    flush() {
+      this._handleMutations(this._observer.takeRecords());
+    },
+
+    setCurrentTag(tagName) {
+      this._newTagName = this._newTagName || tagName;
+    },
+
+    _setNewInstance(instance) {
+      console.assert(this._newInstance == null);
+      this._newInstance = instance;
+    },
+
+    _observeRoot(root) {
+      if (!root.__observer) {
+        var observer = new MutationObserver(this._handleMutations.bind(this));
+        observer.observe(root, {childList: true, subtree: true});
+        root.__observer = observer;
+      }
+      return root.__observer;
+    },
+
+    _handleMutations(mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        var mutation = mutations[i];
+        if (mutation.type === 'childList') {
+          this._addNodes(mutation.addedNodes);
+          this._removeNodes(mutation.removedNodes);
+        }
+      }
+    },
+
+    _addNodes(nodeList) {
+      for (var i = 0; i < nodeList.length; i++) {
+        var root = nodeList[i];
+        var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+        do {
+          var node = walker.currentNode;
+          var definition = this._definitions.get(node.localName);
+          if (!definition) {
+            continue;
+          }
+          if (!node.__upgraded) {
+            this._upgradeElement(node, definition, true);
+          }
+          if (node.__upgraded && !node.__attached) {
+            node.__attached = true;
+            if (definition && definition.connectedCallback) {
+              definition.connectedCallback.call(node);
+            }
+          }
+        } while (walker.nextNode())
+      }
+    },
+
+    _removeNodes(nodeList) {
+      for (var i = 0; i < nodeList.length; i++) {
+        var root = nodeList[i];
+        var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+        do {
+          var node = walker.currentNode;
+          if (node.__upgraded && node.__attached) {
+            node.__attached = false;
+            var definition = this._definitions.get(node.localName);
+            if (definition && definition.disconnectedCallback) {
+              definition.disconnectedCallback.call(node);
+            }
+          }
+        } while (walker.nextNode())
+      }
+    },
+
+    _upgradeElement(element, definition, callConstructor) {
+      var prototype = definition.constructor.prototype;
+      Object.setPrototypeOf(element, prototype);
+      if (callConstructor) {
+        this._setNewInstance(element);
+        element.__upgraded = true;
+        new (definition.constructor)();
+        console.assert(this._newInstance == null);
+      }
+      if (definition.attributeChangedCallback && definition.observedAttributes.length > 0) {
+        this._attributeObserver.observe(element, {
+          attributes: true,
+          attributeOldValue: true,
+          attributeFilter: definition.observedAttributes,
+        });
+      }
+    },
+
+    _handleAttributeChange(mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        var mutation = mutations[i];
+        if (mutation.type === 'attributes') {
+          var name = mutation.attributeName;
+          var oldValue = mutation.oldValue;
+          var target = mutation.target;
+          var newValue = target.getAttribute(name);
+          var namespace = mutation.attributeNamespace;
+          target.attributeChangedCallback(name, oldValue, newValue, namespace);
+        }
+      }
+    },
+
+  };
+
+  function patchHTMLElement(win) {
+    // TODO: patch up all built-in subclasses of HTMLElement to use the fake
+    // HTMLElement.prototype
+    var origHTMLElement = HTMLElement;
+    window.HTMLElement = function() {
+      if (win.customElements._newInstance) {
+        var i = win.customElements._newInstance;
+        win.customElements._newInstance = null;
+        win.customElements._newTagName = null;
+        return i;
+      }
+      if (win.customElements._newTagName) {
+        var tagName = win.customElements._newTagName.toLowerCase();
+        win.customElements._newTagName = null;
+        return win.document._createElement(tagName, false);
+      }
+      throw new Error('unknown constructor');
     }
-    return false;
+    HTMLElement.prototype = Object.create(origHTMLElement.prototype);
+    Object.defineProperty(HTMLElement.prototype, 'constructor', {
+      writable: false,
+      configurable: true,
+      enumerable: false,
+      value: HTMLElement,
+    });
   }
+
+  function patchCreateElement(win) {
+    var doc = win.document;
+    var rawCreateElement = doc.createElement.bind(document);
+    doc._createElement = function(tagName, callConstructor) {
+      var element = rawCreateElement(tagName);
+      var definition = win.customElements._definitions.get(tagName.toLowerCase());
+      if (definition) {
+        win.customElements._upgradeElement(element, definition, callConstructor);
+      }
+      return element;
+    };
+    doc.createElement = function(tagName) {
+      return doc._createElement(tagName, true);
+    }
+  }
+
+  function patchCreateElementNS(win) {
+    var doc = win.document;
+    var HTMLNS = 'http://www.w3.org/1999/xhtml';
+    var _origCreateElementNS = document.createElementNS;
+    doc.createElementNS = function(namespaceURI, qualifiedName) {
+      if (namespaceURI === 'http://www.w3.org/1999/xhtml') {
+        return doc.createElement(qualifiedName);
+      } else {
+        return _origCreateElementNS(namespaceURI, qualifiedName);
+      }
+    };
+  }
+
+  window.customElements = new CustomElementsRegistry();
+  patchHTMLElement(window);
+  patchCreateElement(window);
+  patchCreateElementNS(window);
 })();

--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -164,10 +164,6 @@ var CustomElementDefinition;
       this._handleMutations(this._observer.takeRecords());
     },
 
-    setCurrentTag(tagName) {
-      this._newTagName = this._newTagName || tagName;
-    },
-
     _setNewInstance(instance) {
       this._newInstance = instance;
     },
@@ -277,11 +273,17 @@ var CustomElementDefinition;
       }
     },
   };
+  // TODO: Figure out how to export a setter w/o using defineProperty
+  Object.defineProperty(CustomElementsRegistry.prototype, 'currentTag', {
+    set(tagName) {
+      this._newTagName = this._newTagName || tagName;
+    },
+  });
+
   // Closure Compiler Exports
   window['CustomElementsRegistry'] = CustomElementsRegistry;
   CustomElementsRegistry.prototype['define'] = CustomElementsRegistry.prototype.define;
   CustomElementsRegistry.prototype['flush'] = CustomElementsRegistry.prototype.flush;
-  CustomElementsRegistry.prototype['setCurrentTag'] = CustomElementsRegistry.prototype.setCurrentTag;
   CustomElementsRegistry.prototype['polyfilled'] = CustomElementsRegistry.prototype.polyfilled;
 
   // patch window.HTMLElement

--- a/src/CustomElements/v1/native-shim.js
+++ b/src/CustomElements/v1/native-shim.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This shim allows elements written in, or compiled to, ES5 to work on native
+ * implementations of Custom Elements v1. It sets new.target to the value of
+ * this.constructor so that the native HTMLElement constructor can access the
+ * current under-construction element's definition.
+ *
+ * Because `new.target` is a syntax error in VMs that don't support it, this
+ * shim must only be loaded in browsers that do.
+ */
+(() => {
+  let origHTMLElement = HTMLElement;
+  window.HTMLElement = function() {
+    // prefer new.target for elements that call super() constructors or
+    // Reflect.construct directly
+    let newTarget = new.target || this.constructor;
+    return Reflect.construct(origHTMLElement, [], newTarget);
+  }
+  HTMLElement.prototype = Object.create(origHTMLElement);
+  Object.defineProperty(HTMLElement.prototype, 'constructor', {value: HTMLElement});
+  // TODO: patch all native subclasses of HTMLElement
+})();

--- a/tests/CustomElements/v1/js/babel.js
+++ b/tests/CustomElements/v1/js/babel.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('babel', function() {
+
+  // Fails because the XTypescript constructor does not return the result of
+  // the super call. See: https://github.com/Microsoft/TypeScript/issues/7574
+  test('document.defineElement create typescript generated ES5 via new', function() {
+    'use strict';
+
+    function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+    function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+    function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+    var XBabel = function (_HTMLElement) {
+      _inherits(XBabel, _HTMLElement);
+
+      function XBabel() {
+        _classCallCheck(this, XBabel);
+
+        CustomElements.setCurrentTag('x-babel');
+        return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel).call(this));
+      }
+
+      return XBabel;
+    }(HTMLElement);
+
+    // register x-foo
+    document.defineElement('x-babel', XBabel);
+    // create an instance via new
+    var e = new XBabel();
+    console.log(e);
+    // test localName
+    assert.equal(e.localName, 'x-babel');
+    // test instanceof
+    assert.instanceOf(e, XBabel);
+  });
+
+  test('document.defineElement create typescript generated ES5 via createElement', function() {
+    'use strict';
+
+    function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+    function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+    function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+    var XBabel2 = function (_HTMLElement) {
+      _inherits(XBabel2, _HTMLElement);
+
+      function XBabel2() {
+        _classCallCheck(this, XBabel2);
+
+        CustomElements.setCurrentTag('x-babel2');
+        return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel2).call(this));
+      }
+
+      return XBabel2;
+    }(HTMLElement);
+
+    // register x-foo
+    document.defineElement('x-babel2', XBabel2);
+    // create an instance via new
+    var e = document.createElement('x-babel2');
+    console.log(e);
+    // test localName
+    assert.equal(e.localName, 'x-babel2');
+    // test instanceof
+    assert.instanceOf(e, XBabel2);
+  });
+
+});

--- a/tests/CustomElements/v1/js/babel.js
+++ b/tests/CustomElements/v1/js/babel.js
@@ -12,7 +12,7 @@ suite('babel', function() {
 
   // Fails because the XTypescript constructor does not return the result of
   // the super call. See: https://github.com/Microsoft/TypeScript/issues/7574
-  test('document.defineElement create typescript generated ES5 via new', function() {
+  test('document.defineElement create babel generated ES5 via new', function() {
     'use strict';
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -45,7 +45,7 @@ suite('babel', function() {
     assert.instanceOf(e, XBabel);
   });
 
-  test('document.defineElement create typescript generated ES5 via createElement', function() {
+  test('document.defineElement create babel generated ES5 via createElement', function() {
     'use strict';
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }

--- a/tests/CustomElements/v1/js/babel.js
+++ b/tests/CustomElements/v1/js/babel.js
@@ -27,7 +27,7 @@ suite('babel', function() {
       function XBabel() {
         _classCallCheck(this, XBabel);
 
-        customElements.setCurrentTag('x-babel');
+        customElements.currentTag = 'x-babel';
         return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel).call(this));
       }
 
@@ -60,7 +60,7 @@ suite('babel', function() {
       function XBabel2() {
         _classCallCheck(this, XBabel2);
 
-        customElements.setCurrentTag('x-babel2');
+        customElements.currentTag = 'x-babel2';
         return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel2).call(this));
       }
 

--- a/tests/CustomElements/v1/js/babel.js
+++ b/tests/CustomElements/v1/js/babel.js
@@ -12,7 +12,7 @@ suite('babel', function() {
 
   // Fails because the XTypescript constructor does not return the result of
   // the super call. See: https://github.com/Microsoft/TypeScript/issues/7574
-  test('document.defineElement create babel generated ES5 via new', function() {
+  test('customElements.define create babel generated ES5 via new', function() {
     'use strict';
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -35,7 +35,7 @@ suite('babel', function() {
     }(HTMLElement);
 
     // register x-foo
-    document.defineElement('x-babel', XBabel);
+    customElements.define('x-babel', XBabel);
     // create an instance via new
     var e = new XBabel();
     console.log(e);
@@ -45,7 +45,7 @@ suite('babel', function() {
     assert.instanceOf(e, XBabel);
   });
 
-  test('document.defineElement create babel generated ES5 via createElement', function() {
+  test('customElements.define create babel generated ES5 via createElement', function() {
     'use strict';
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -68,7 +68,7 @@ suite('babel', function() {
     }(HTMLElement);
 
     // register x-foo
-    document.defineElement('x-babel2', XBabel2);
+    customElements.define('x-babel2', XBabel2);
     // create an instance via new
     var e = document.createElement('x-babel2');
     console.log(e);

--- a/tests/CustomElements/v1/js/babel.js
+++ b/tests/CustomElements/v1/js/babel.js
@@ -27,7 +27,6 @@ suite('babel', function() {
       function XBabel() {
         _classCallCheck(this, XBabel);
 
-        customElements.currentTag = 'x-babel';
         return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel).call(this));
       }
 
@@ -38,7 +37,6 @@ suite('babel', function() {
     customElements.define('x-babel', XBabel);
     // create an instance via new
     var e = new XBabel();
-    console.log(e);
     // test localName
     assert.equal(e.localName, 'x-babel');
     // test instanceof
@@ -60,7 +58,6 @@ suite('babel', function() {
       function XBabel2() {
         _classCallCheck(this, XBabel2);
 
-        customElements.currentTag = 'x-babel2';
         return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel2).call(this));
       }
 
@@ -71,7 +68,6 @@ suite('babel', function() {
     customElements.define('x-babel2', XBabel2);
     // create an instance via new
     var e = document.createElement('x-babel2');
-    console.log(e);
     // test localName
     assert.equal(e.localName, 'x-babel2');
     // test instanceof

--- a/tests/CustomElements/v1/js/babel.js
+++ b/tests/CustomElements/v1/js/babel.js
@@ -27,7 +27,7 @@ suite('babel', function() {
       function XBabel() {
         _classCallCheck(this, XBabel);
 
-        CustomElements.setCurrentTag('x-babel');
+        customElements.setCurrentTag('x-babel');
         return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel).call(this));
       }
 
@@ -60,7 +60,7 @@ suite('babel', function() {
       function XBabel2() {
         _classCallCheck(this, XBabel2);
 
-        CustomElements.setCurrentTag('x-babel2');
+        customElements.setCurrentTag('x-babel2');
         return _possibleConstructorReturn(this, Object.getPrototypeOf(XBabel2).call(this));
       }
 

--- a/tests/CustomElements/v1/js/closure.js
+++ b/tests/CustomElements/v1/js/closure.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('babel', function() {
+
+  // Fails because the XTypescript constructor does not return the result of
+  // the super call. See: https://github.com/Microsoft/TypeScript/issues/7574
+  test('customElements.define create babel generated ES5 via new', function() {
+    'use strict';
+
+    // Closure standard library code
+    var $jscomp = {scope:{}, getGlobal:function(a) {
+      return "undefined" != typeof window && window === a ? a : "undefined" != typeof global ? global : a;
+    }};
+    $jscomp.global = $jscomp.getGlobal(this);
+    $jscomp.inherits = function(a, b) {
+      function c() {
+      }
+      c.prototype = b.prototype;
+      a.prototype = new c;
+      a.prototype.constructor = a;
+      for (var d in b) {
+        if ($jscomp.global.Object.defineProperties) {
+          var e = $jscomp.global.Object.getOwnPropertyDescriptor(b, d);
+          e && $jscomp.global.Object.defineProperty(a, d, e);
+        } else {
+          a[d] = b[d];
+        }
+      }
+    };
+
+    // Compiled test
+    var XFoo = function(a) {
+      HTMLElement.apply(this, arguments);
+    };
+    $jscomp.inherits(XFoo, HTMLElement);
+    customElements.define("x-foo", XFoo);
+    var xfoo = new XFoo;
+    assert.equal(xfoo.localName, "x-foo");
+    assert.instanceOf(xfoo, XFoo);
+  });
+
+});

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -285,11 +285,11 @@ suite('customElements', function() {
         this.detached = false;
       }
 
-      attachedCallback() {
+      connectedCallback() {
         this.attached = true;
       }
 
-      detachedCallback() {
+      disconnectedCallback() {
         this.detached = true;
       }
     }
@@ -335,14 +335,14 @@ suite('customElements', function() {
     xboo.setAttribute('foo', 'zot');
   });
 
-  test('customElements.define attachedCallbacks in prototype', function(done) {
+  test('customElements.define connectedCallbacks in prototype', function(done) {
     var inserted = 0;
     class XBoo extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-boo-at');
         super();
       }
-      attachedCallback() {
+      connectedCallback() {
         inserted++;
       }
     }
@@ -361,14 +361,14 @@ suite('customElements', function() {
     done();
   });
 
-  test('document.registerElement detachedCallbacks in prototype', function(done) {
+  test('document.registerElement disconnectedCallbacks in prototype', function(done) {
     var ready, inserted, removed;
     class XBoo extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-boo-ir2');
         super();
       }
-      detachedCallback() {
+      disconnectedCallback() {
         removed = true;
       }
     }
@@ -387,7 +387,7 @@ suite('customElements', function() {
         CustomElements.setCurrentTag('x-booboo-ir2');
         super();
       }
-      detachedCallback() {
+      disconnectedCallback() {
         removed = true;
       }
     }
@@ -468,10 +468,10 @@ suite('customElements', function() {
   //   elementProto.createdCallback = function() {
   //     invocations.push('created');
   //   }
-  //   elementProto.attachedCallback = function() {
+  //   elementProto.connectedCallback = function() {
   //     invocations.push('entered');
   //   }
-  //   elementProto.detachedCallback = function() {
+  //   elementProto.disconnectedCallback = function() {
   //     invocations.push('left');
   //   }
   //   var tagName = 'x-entered-left-view';
@@ -498,10 +498,10 @@ suite('customElements', function() {
   //       'created, entered then left view');
   // });
   //
-  // test('attachedCallback ordering', function() {
+  // test('connectedCallback ordering', function() {
   //   var log = [];
   //   var p = Object.create(HTMLElement.prototype);
-  //   p.attachedCallback = function() {
+  //   p.connectedCallback = function() {
   //     log.push(this.id);
   //   };
   //   document.registerElement('x-boo-ordering', {prototype: p});
@@ -522,10 +522,10 @@ suite('customElements', function() {
   // test('attached and detached in same turn', function(done) {
   //   var log = [];
   //   var p = Object.create(HTMLElement.prototype);
-  //   p.attachedCallback = function() {
+  //   p.connectedCallback = function() {
   //     log.push('attached');
   //   };
-  //   p.detachedCallback = function() {
+  //   p.disconnectedCallback = function() {
   //     log.push('detached');
   //   };
   //   document.registerElement('x-ad', {prototype: p});
@@ -541,10 +541,10 @@ suite('customElements', function() {
   // test('detached and re-attached in same turn', function(done) {
   //   var log = [];
   //   var p = Object.create(HTMLElement.prototype);
-  //   p.attachedCallback = function() {
+  //   p.connectedCallback = function() {
   //     log.push('attached');
   //   };
-  //   p.detachedCallback = function() {
+  //   p.disconnectedCallback = function() {
   //     log.push('detached');
   //   };
   //   document.registerElement('x-da', {prototype: p});
@@ -560,10 +560,10 @@ suite('customElements', function() {
   //   });
   // });
   //
-  // test('detachedCallback ordering', function() {
+  // test('disconnectedCallback ordering', function() {
   //   var log = [];
   //   var p = Object.create(HTMLElement.prototype);
-  //   p.detachedCallback = function() {
+  //   p.disconnectedCallback = function() {
   //    log.push(this.id);
   //   };
   //   document.registerElement('x-boo2-ordering', {prototype: p});

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -128,7 +128,6 @@ suite('customElements', function() {
     document.defineElement('x-foo-es5', XFooES5);
     // create an instance via new
     var xfoo = new XFooES5();
-    console.log(xfoo);
     // test localName
     assert.equal(xfoo.localName, 'x-foo-es5');
     // test instanceof
@@ -197,276 +196,212 @@ suite('customElements', function() {
     document.defineElement('x-bar-es5', XBarES5);
     // create an instance via createElement
     var xbar = document.createElement('x-bar-es5');
-    console.log(xbar);
     // test localName
     assert.equal(xbar.localName, 'x-bar-es5');
     // test instanceof
     assert.instanceOf(xbar, XBarES5);
   });
 
-  // test('document.registerElement create via createElementNS', function() {
-  //   // create an instance via createElementNS
-  //   var xfoo = document.createElementNS(HTMLNS, 'x-foo2');
-  //   // test localName
-  //   assert.equal(xfoo.localName, 'x-foo2');
-  //   // attach content
-  //   xfoo.textContent = '[x-foo2]';
-  //   // test textContent
-  //   assert.equal(xfoo.textContent, '[x-foo2]');
-  // });
-  //
-  // test('document.registerElement treats names as case insensitive', function() {
-  //   var proto = {prototype: Object.create(HTMLElement.prototype)};
-  //   proto.prototype.isXCase = true;
-  //   var XCase = document.registerElement('X-CASE', proto);
-  //   // createElement
-  //   var x = document.createElement('X-CASE');
-  //   assert.equal(x.isXCase, true);
-  //   x = document.createElement('x-case');
-  //   assert.equal(x.isXCase, true);
-  //   // createElementNS
-  //   // NOTE: createElementNS is case sensitive, disable tests
-  //   // x = document.createElementNS(HTMLNS, 'X-CASE');
-  //   // assert.equal(x.isXCase, true);
-  //   // x = document.createElementNS(HTMLNS, 'x-case');
-  //   // assert.equal(x.isXCase, true);
-  //   // upgrade
-  //   work.innerHTML = '<X-CASE></X-CASE><x-CaSe></x-CaSe>';
-  //   CustomElements.takeRecords();
-  //   assert.equal(work.firstChild.isXCase, true);
-  //   assert.equal(work.firstChild.nextSibling.isXCase, true);
-  // });
-  //
-  // test('document.registerElement create multiple instances', function() {
-  //   var XFooPrototype = Object.create(HTMLElement.prototype);
-  //   XFooPrototype.bluate = function() {
-  //     this.color = 'lightblue';
-  //   };
-  //   var XFoo = document.registerElement('x-foo3', {
-  //     prototype: XFooPrototype
-  //   });
-  //   // create an instance
-  //   var xfoo1 = new XFoo();
-  //   // create another instance
-  //   var xfoo2 = new XFoo();
-  //   // test textContent
-  //   xfoo1.textContent = '[x-foo1]';
-  //   xfoo2.textContent = '[x-foo2]';
-  //   assert.equal(xfoo1.textContent, '[x-foo1]');
-  //   assert.equal(xfoo2.textContent, '[x-foo2]');
-  //   // test bluate
-  //   xfoo1.bluate();
-  //   assert.equal(xfoo1.color, 'lightblue');
-  //   assert.isUndefined(xfoo2.color);
-  // });
-  //
-  // test('document.registerElement extend native element', function() {
-  //   // test native element extension
-  //   var XBarPrototype = Object.create(HTMLButtonElement.prototype);
-  //   var XBar = document.registerElement('x-bar', {
-  //     prototype: XBarPrototype,
-  //     extends: 'button'
-  //   });
-  //   var xbar = new XBar();
-  //   work.appendChild(xbar).textContent = 'x-bar';
-  //   xbar = work.querySelector('button[is=x-bar]');
-  //   assert(xbar);
-  //   assert.equal(xbar.textContent, 'x-bar');
-  //   // test extension of native element extension
-  //   var XBarBarPrototype = Object.create(XBarPrototype);
-  //   var XBarBar = document.registerElement('x-barbar', {
-  //     prototype: XBarBarPrototype,
-  //     extends: 'button'
-  //   });
-  //   var xbarbar = new XBarBar();
-  //   work.appendChild(xbarbar).textContent = 'x-barbar';
-  //   xbarbar = work.querySelector('button[is=x-barbar]');
-  //   assert(xbarbar);
-  //   assert.equal(xbarbar.textContent, 'x-barbar');
-  //   // test extension^3
-  //   var XBarBarBarPrototype = Object.create(XBarBarPrototype);
-  //   var XBarBarBar = document.registerElement('x-barbarbar', {
-  //     prototype: XBarBarBarPrototype,
-  //     extends: 'button'
-  //   });
-  //   var xbarbarbar = new XBarBarBar();
-  //   work.appendChild(xbarbarbar).textContent = 'x-barbarbar';
-  //   xbarbarbar = work.querySelector('button[is=x-barbarbar]');
-  //   assert(xbarbarbar);
-  //   assert.equal(xbarbarbar.textContent, 'x-barbarbar');
-  // });
-  //
-  // test('document.registerElement with type extension treats names as case insensitive', function() {
-  //   var proto = {prototype: Object.create(HTMLButtonElement.prototype), extends: 'button'};
-  //   proto.prototype.isXCase = true;
-  //   var XCase = document.registerElement('X-EXTEND-CASE', proto);
-  //   // createElement
-  //   var x = document.createElement('button', 'X-EXTEND-CASE');
-  //   assert.equal(x.isXCase, true);
-  //   x = document.createElement('button', 'x-extend-case');
-  //   assert.equal(x.isXCase, true);
-  //   x = document.createElement('BUTTON', 'X-EXTEND-CASE');
-  //   assert.equal(x.isXCase, true);
-  //   x = document.createElement('BUTTON', 'x-extend-case');
-  //   assert.equal(x.isXCase, true);
-  //   // upgrade
-  //   work.innerHTML = '<button is="X-EXTEND-CASE"></button><button is="x-ExTeNd-CaSe"></button>';
-  //   CustomElements.takeRecords();
-  //   assert.equal(work.firstChild.isXCase, true);
-  //   assert.equal(work.firstChild.nextSibling.isXCase, true);
-  // });
-  //
-  // test('document.registerElement createdCallback in prototype', function() {
-  //   var XBooPrototype = Object.create(HTMLElement.prototype);
-  //   XBooPrototype.createdCallback = function() {
-  //     this.style.fontStyle = 'italic';
-  //   }
-  //   var XBoo = document.registerElement('x-boo', {
-  //     prototype: XBooPrototype
-  //   });
-  //   var xboo = new XBoo();
-  //   assert.equal(xboo.style.fontStyle, 'italic');
-  //   //
-  //   var XBooBooPrototype = Object.create(XBooPrototype);
-  //   XBooBooPrototype.createdCallback = function() {
-  //     XBoo.prototype.createdCallback.call(this);
-  //     this.style.fontSize = '32pt';
-  //   };
-  //   var XBooBoo = document.registerElement('x-booboo', {
-  //     prototype: XBooBooPrototype
-  //   });
-  //   var xbooboo = new XBooBoo();
-  //   assert.equal(xbooboo.style.fontStyle, 'italic');
-  //   assert.equal(xbooboo.style.fontSize, '32pt');
-  // });
-  //
-  // test('document.registerElement [created|attached|detached]Callbacks in prototype', function(done) {
-  //   var ready, inserted, removed;
-  //   var XBooPrototype = Object.create(HTMLElement.prototype);
-  //   XBooPrototype.createdCallback = function() {
-  //     ready = true;
-  //   }
-  //   XBooPrototype.attachedCallback = function() {
-  //     inserted = true;
-  //   }
-  //   XBooPrototype.detachedCallback = function() {
-  //     removed = true;
-  //   }
-  //   var XBoo = document.registerElement('x-boo-ir', {
-  //     prototype: XBooPrototype
-  //   });
-  //   var xboo = new XBoo();
-  //   assert(ready, 'ready must be true [XBoo]');
-  //   assert(!inserted, 'inserted must be false [XBoo]');
-  //   assert(!removed, 'removed must be false [XBoo]');
-  //   work.appendChild(xboo);
-  //   CustomElements.takeRecords();
-  //   assert(inserted, 'inserted must be true [XBoo]');
-  //   work.removeChild(xboo);
-  //   CustomElements.takeRecords();
-  //   assert(removed, 'removed must be true [XBoo]');
-  //   //
-  //   ready = inserted = removed = false;
-  //   var XBooBooPrototype = Object.create(XBooPrototype);
-  //   XBooBooPrototype.createdCallback = function() {
-  //     XBoo.prototype.createdCallback.call(this);
-  //   };
-  //   XBooBooPrototype.attachedCallback = function() {
-  //     XBoo.prototype.attachedCallback.call(this);
-  //   };
-  //   XBooBooPrototype.detachedCallback = function() {
-  //     XBoo.prototype.detachedCallback.call(this);
-  //   };
-  //   var XBooBoo = document.registerElement('x-booboo-ir', {
-  //     prototype: XBooBooPrototype
-  //   });
-  //   var xbooboo = new XBooBoo();
-  //   assert(ready, 'ready must be true [XBooBoo]');
-  //   assert(!inserted, 'inserted must be false [XBooBoo]');
-  //   assert(!removed, 'removed must be false [XBooBoo]');
-  //   work.appendChild(xbooboo);
-  //   CustomElements.takeRecords();
-  //   assert(inserted, 'inserted must be true [XBooBoo]');
-  //   work.removeChild(xbooboo);
-  //   CustomElements.takeRecords();
-  //   assert(removed, 'removed must be true [XBooBoo]');
-  //   done();
-  // });
-  //
-  // test('document.registerElement attributeChangedCallback in prototype', function(done) {
-  //   var XBooPrototype = Object.create(HTMLElement.prototype);
-  //   XBooPrototype.attributeChangedCallback = function(inName, inOldValue) {
-  //     if (inName == 'foo' && inOldValue=='bar'
-  //         && this.attributes.foo.value == 'zot') {
-  //       done();
-  //     }
-  //   }
-  //   var XBoo = document.registerElement('x-boo-acp', {
-  //     prototype: XBooPrototype
-  //   });
-  //   var xboo = new XBoo();
-  //   xboo.setAttribute('foo', 'bar');
-  //   xboo.setAttribute('foo', 'zot');
-  // });
-  //
-  // test('document.registerElement attachedCallbacks in prototype', function(done) {
-  //   var inserted = 0;
-  //   var XBooPrototype = Object.create(HTMLElement.prototype);
-  //   XBooPrototype.attachedCallback = function() {
-  //     inserted++;
-  //   };
-  //   var XBoo = document.registerElement('x-boo-at', {
-  //     prototype: XBooPrototype
-  //   });
-  //   var xboo = new XBoo();
-  //   assert.equal(inserted, 0, 'inserted must be 0');
-  //   work.appendChild(xboo);
-  //   CustomElements.takeRecords();
-  //   assert.equal(inserted, 1, 'inserted must be 1');
-  //   work.removeChild(xboo);
-  //   CustomElements.takeRecords();
-  //   assert(!xboo.parentNode);
-  //   work.appendChild(xboo);
-  //   CustomElements.takeRecords();
-  //   assert.equal(inserted, 2, 'inserted must be 2');
-  //   done();
-  // });
-  //
-  // test('document.registerElement detachedCallbacks in prototype', function(done) {
-  //   var ready, inserted, removed;
-  //   var XBooPrototype = Object.create(HTMLElement.prototype);
-  //   XBooPrototype.detachedCallback = function() {
-  //     removed = true;
-  //   }
-  //   var XBoo = document.registerElement('x-boo-ir2', {
-  //     prototype: XBooPrototype
-  //   });
-  //   var xboo = new XBoo();
-  //   assert(!removed, 'removed must be false [XBoo]');
-  //   work.appendChild(xboo);
-  //   CustomElements.takeRecords();
-  //   work.removeChild(xboo);
-  //   CustomElements.takeRecords();
-  //   assert(removed, 'removed must be true [XBoo]');
-  //   //
-  //   ready = inserted = removed = false;
-  //   var XBooBooPrototype = Object.create(XBooPrototype);
-  //   XBooBooPrototype.detachedCallback = function() {
-  //     XBoo.prototype.detachedCallback.call(this);
-  //   };
-  //   var XBooBoo = document.registerElement('x-booboo-ir2', {
-  //     prototype: XBooBooPrototype
-  //   });
-  //   var xbooboo = new XBooBoo();
-  //   assert(!removed, 'removed must be false [XBooBoo]');
-  //   work.appendChild(xbooboo);
-  //   CustomElements.takeRecords();
-  //   work.removeChild(xbooboo);
-  //   CustomElements.takeRecords();
-  //   assert(removed, 'removed must be true [XBooBoo]');
-  //   done();
-  // });
-  //
+  test('document.defineElement create via createElementNS', function() {
+    class XFoo3 extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-foo3');
+        super();
+      }
+    }
+    // register x-foo
+    document.defineElement('x-foo3', XFoo3);
+    // create an instance via createElementNS
+    var xfoo = document.createElementNS(HTMLNS, 'x-foo3');
+    // test instanceof
+    assert.instanceOf(xfoo, XFoo3);
+    // test localName
+    assert.equal(xfoo.localName, 'x-foo3');
+  });
+
+  test('document.defineElement treats names as case insensitive', function() {
+    class XCase extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-case');
+        super();
+        this.isXCase = true;
+      }
+    }
+    document.defineElement('X-CASE', XCase);
+    // createElement
+    var x = document.createElement('X-CASE');
+    assert.equal(x.isXCase, true);
+    x = document.createElement('x-case');
+    assert.equal(x.isXCase, true);
+    // createElementNS
+    // NOTE: createElementNS is case sensitive, disable tests
+    // x = document.createElementNS(HTMLNS, 'X-CASE');
+    // assert.equal(x.isXCase, true);
+    // x = document.createElementNS(HTMLNS, 'x-case');
+    // assert.equal(x.isXCase, true);
+    // upgrade
+
+    // TODO: uncomment when upgrades implemented
+    // work.innerHTML = '<X-CASE></X-CASE><x-CaSe></x-CaSe>';
+    // CustomElements.takeRecords();
+    // assert.equal(work.firstChild.isXCase, true);
+    // assert.equal(work.firstChild.nextSibling.isXCase, true);
+  });
+
+  test('document.defineElement create multiple instances', function() {
+    // create an instance
+    var xfoo1 = document.createElement('x-foo');
+    // create another instance
+    var xfoo2 = document.createElement('x-foo');
+
+    assert.notStrictEqual(xfoo1, xfoo2);
+    // test textContent
+    xfoo1.textContent = '[x-foo1]';
+    xfoo2.textContent = '[x-foo2]';
+    assert.equal(xfoo1.textContent, '[x-foo1]');
+    assert.equal(xfoo2.textContent, '[x-foo2]');
+  });
+
+  test('document.defineElement calls constructor only once', function() {
+    var count = 0;
+    class XConstructor extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-constructor');
+        super();
+        count++;
+      }
+    }
+    document.defineElement('x-constructor', XConstructor);
+    var xconstructor = new XConstructor();
+    assert.equal(count, 1);
+  });
+
+  test('document.defineElement [attached|detached]Callbacks', function(done) {
+    class XCallbacks extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-callbacks');
+        super();
+        this.attached = false;
+        this.detached = false;
+      }
+
+      attachedCallback() {
+        this.attached = true;
+      }
+
+      detachedCallback() {
+        this.detached = true;
+      }
+    }
+    document.defineElement('x-callbacks', XCallbacks);
+    var e = new XCallbacks();
+    assert.isFalse(e.attached);
+    assert.isFalse(e.detached);
+
+    work.appendChild(e);
+    CustomElements.flush();
+    assert.isTrue(e.attached);
+    assert.isFalse(e.detached);
+
+    work.removeChild(e);
+    CustomElements.flush();
+    assert.isTrue(e.attached);
+    assert.isTrue(e.detached);
+
+    done();
+  });
+
+
+  test('document.defineElement attributeChangedCallback in prototype', function(done) {
+    class XBoo extends HTMLElement {
+      static get observedAttributes() {
+        return ['foo'];
+      }
+
+      constructor() {
+        CustomElements.setCurrentTag('x-boo-acp');
+        super();
+      }
+      attributeChangedCallback(inName, inOldValue) {
+        if (inName == 'foo' && inOldValue=='bar'
+            && this.attributes.foo.value == 'zot') {
+          done();
+        }
+      }
+    }
+    document.defineElement('x-boo-acp', XBoo);
+    var xboo = new XBoo();
+    xboo.setAttribute('foo', 'bar');
+    xboo.setAttribute('foo', 'zot');
+  });
+
+  test('document.defineElement attachedCallbacks in prototype', function(done) {
+    var inserted = 0;
+    class XBoo extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-boo-at');
+        super();
+      }
+      attachedCallback() {
+        inserted++;
+      }
+    }
+    document.defineElement('x-boo-at', XBoo);
+    var xboo = new XBoo();
+    assert.equal(inserted, 0, 'inserted must be 0');
+    work.appendChild(xboo);
+    CustomElements.flush();
+    assert.equal(inserted, 1, 'inserted must be 1');
+    work.removeChild(xboo);
+    CustomElements.flush();
+    assert(!xboo.parentNode);
+    work.appendChild(xboo);
+    CustomElements.flush();
+    assert.equal(inserted, 2, 'inserted must be 2');
+    done();
+  });
+
+  test('document.registerElement detachedCallbacks in prototype', function(done) {
+    var ready, inserted, removed;
+    class XBoo extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-boo-ir2');
+        super();
+      }
+      detachedCallback() {
+        removed = true;
+      }
+    }
+    document.defineElement('x-boo-ir2', XBoo);
+    var xboo = new XBoo();
+    assert(!removed, 'removed must be false [XBoo]');
+    work.appendChild(xboo);
+    CustomElements.flush();
+    work.removeChild(xboo);
+    CustomElements.flush();
+    assert(removed, 'removed must be true [XBoo]');
+
+    ready = inserted = removed = false;
+    class XBooBoo extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-booboo-ir2');
+        super();
+      }
+      detachedCallback() {
+        removed = true;
+      }
+    }
+    document.defineElement('x-booboo-ir2', XBooBoo);
+    var xbooboo = new XBooBoo();
+    assert(!removed, 'removed must be false [XBooBoo]');
+    work.appendChild(xbooboo);
+    CustomElements.flush();
+    work.removeChild(xbooboo);
+    CustomElements.flush();
+    assert(removed, 'removed must be true [XBooBoo]');
+    done();
+  });
+
   // test('document.registerElement can use Functions as definitions', function() {
   //   // function used as Custom Element defintion
   //   function A$A() {
@@ -484,39 +419,49 @@ suite('customElements', function() {
   //   CustomElements.takeRecords();
   //   assert.equal(work.firstElementChild.alive, true);
   // });
-  //
-  // test('node.cloneNode upgrades', function(done) {
-  //   var XBooPrototype = Object.create(HTMLElement.prototype);
-  //   XBooPrototype.createdCallback = function() {
-  //     this.__ready__ = true;
-  //   };
-  //   var XBoo = document.registerElement('x-boo-clone', {
-  //     prototype: XBooPrototype
-  //   });
-  //   var xboo = new XBoo();
-  //   work.appendChild(xboo);
-  //   CustomElements.takeRecords();
-  //   var xboo2 = xboo.cloneNode(true);
-  //   assert(xboo2.__ready__, 'clone createdCallback must be called');
-  //   done();
-  // });
-  //
-  // test('document.importNode upgrades', function() {
-  //   var XImportPrototype = Object.create(HTMLElement.prototype);
-  //   XImportPrototype.createdCallback = function() {
-  //     this.__ready__ = true;
-  //   };
-  //   document.registerElement('x-import', {
-  //     prototype: XImportPrototype
-  //   });
-  //   var frag = document.createDocumentFragment();
-  //   frag.appendChild(document.createElement('x-import'));
-  //   assert.isTrue(frag.firstChild.__ready__, 'source element upgraded');
-  //   var imported = document.importNode(frag, true);
-  //   window.imported = imported;
-  //   assert.isTrue(imported.firstChild.__ready__, 'imported element upgraded');
-  // });
-  //
+
+  test('node.cloneNode does not upgrade until attach', function(done) {
+    class XBoo extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-boo-clone');
+        super();
+        this.__ready__ = true;
+      }
+    }
+    document.defineElement('x-boo-clone', XBoo);
+    var xboo = new XBoo();
+    work.appendChild(xboo);
+    CustomElements.flush();
+    var xboo2 = xboo.cloneNode(true);
+    CustomElements.flush();
+    assert.isNotOk(xboo2.__ready__, 'clone createdCallback must be called');
+    work.appendChild(xboo2);
+    CustomElements.flush();
+    assert.isTrue(xboo2.__ready__, 'clone createdCallback must be called');
+    done();
+  });
+
+  test('document.importNode upgrades', function() {
+    class XImport extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-import');
+        super();
+        this.__ready__ = true;
+      }
+    }
+    document.defineElement('x-import', XImport);
+    var frag = document.createDocumentFragment();
+    frag.appendChild(document.createElement('x-import'));
+    assert.isTrue(frag.firstChild.__ready__, 'source element upgraded');
+    var imported = document.importNode(frag, true);
+    window.imported = imported;
+    var importedEl = imported.firstChild;
+    assert.isNotOk(importedEl.__ready__, 'imported element upgraded');
+    work.appendChild(imported);
+    CustomElements.flush();
+    assert.isOk(importedEl.__ready__, 'imported element upgraded');
+  });
+
   // test('entered left apply to view', function() {
   //   var invocations = [];
   //   var elementProto = Object.create(HTMLElement.prototype);

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -65,12 +65,7 @@ suite('customElements', function() {
   });
 
   test('customElements.define create via new', function() {
-    class XFoo extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-foo';
-        super();
-      }
-    }
+    class XFoo extends HTMLElement {}
     // register x-foo
     customElements.define('x-foo', XFoo);
     // create an instance via new
@@ -88,18 +83,8 @@ suite('customElements', function() {
   });
 
   test('customElements.define create subclass via new', function() {
-    class XSuper1 extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-super-1';
-        super();
-      }
-    }
-    class XSub1 extends XSuper1 {
-      constructor() {
-        customElements.currentTag = 'x-sub-1';
-        super();
-      }
-    }
+    class XSuper1 extends HTMLElement {}
+    class XSub1 extends XSuper1 {}
     customElements.define('x-super-1', XSuper1);
     customElements.define('x-sub-1', XSub1);
 
@@ -118,12 +103,11 @@ suite('customElements', function() {
 
   test('customElements.define create ES5 via new', function() {
     function XFooES5() {
-      customElements.currentTag = 'x-foo-es5';
       // Note the return is super (ahem) important!
       return HTMLElement.call(this);
     }
     XFooES5.prototype = Object.create(HTMLElement.prototype);
-    XFooES5.prototype.constructor = XFooES5;
+    Object.defineProperty(XFooES5.prototype, 'constructor', {value: XFooES5});
     // register x-foo
     customElements.define('x-foo-es5', XFooES5);
     // create an instance via new
@@ -135,12 +119,7 @@ suite('customElements', function() {
   });
 
   test('customElements.define create via createElement', function() {
-    class XFoo2 extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-foo';
-        super();
-      }
-    }
+    class XFoo2 extends HTMLElement {}
     // register x-foo
     var XFoo = customElements.define('x-foo2', XFoo2);
     // create an instance via createElement
@@ -156,18 +135,8 @@ suite('customElements', function() {
   });
 
   test('customElements.define create subclass via createElement', function() {
-    class XSuper2 extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-super-1';
-        super();
-      }
-    }
-    class XSub2 extends XSuper2 {
-      constructor() {
-        customElements.currentTag = 'x-sub-1';
-        super();
-      }
-    }
+    class XSuper2 extends HTMLElement {}
+    class XSub2 extends XSuper2 {}
     customElements.define('x-super-2', XSuper2);
     customElements.define('x-sub-2', XSub2);
 
@@ -187,11 +156,10 @@ suite('customElements', function() {
 
   test('customElements.define create ES5 via createElement', function() {
     function XBarES5() {
-      customElements.currentTag = 'x-bar-es5';
       return HTMLElement.call(this);
     }
     XBarES5.prototype = Object.create(HTMLElement.prototype);
-    XBarES5.prototype.constructor = XBarES5;
+    Object.defineProperty(XBarES5.prototype, 'constructor', {value: XBarES5});
     // register x-foo
     customElements.define('x-bar-es5', XBarES5);
     // create an instance via createElement
@@ -203,12 +171,7 @@ suite('customElements', function() {
   });
 
   test('customElements.define create via createElementNS', function() {
-    class XFoo3 extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-foo3';
-        super();
-      }
-    }
+    class XFoo3 extends HTMLElement {}
     // register x-foo
     customElements.define('x-foo3', XFoo3);
     // create an instance via createElementNS
@@ -222,7 +185,6 @@ suite('customElements', function() {
   test('customElements.define treats names as case insensitive', function() {
     class XCase extends HTMLElement {
       constructor() {
-        customElements.currentTag = 'x-case';
         super();
         this.isXCase = true;
       }
@@ -266,7 +228,6 @@ suite('customElements', function() {
     var count = 0;
     class XConstructor extends HTMLElement {
       constructor() {
-        customElements.currentTag = 'x-constructor';
         super();
         count++;
       }
@@ -279,7 +240,6 @@ suite('customElements', function() {
   test('customElements.define [attached|detached]Callbacks', function(done) {
     class XCallbacks extends HTMLElement {
       constructor() {
-        customElements.currentTag = 'x-callbacks';
         super();
         this.attached = false;
         this.detached = false;
@@ -318,10 +278,6 @@ suite('customElements', function() {
         return ['foo'];
       }
 
-      constructor() {
-        customElements.currentTag = 'x-boo-acp';
-        super();
-      }
       attributeChangedCallback(inName, inOldValue) {
         if (inName == 'foo' && inOldValue == 'bar'
             && this.attributes.foo.value == 'zot') {
@@ -338,10 +294,6 @@ suite('customElements', function() {
   test('customElements.define connectedCallbacks in prototype', function(done) {
     var inserted = 0;
     class XBoo extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-boo-at';
-        super();
-      }
       connectedCallback() {
         inserted++;
       }
@@ -364,10 +316,6 @@ suite('customElements', function() {
   test('document.registerElement disconnectedCallbacks in prototype', function(done) {
     var ready, inserted, removed;
     class XBoo extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-boo-ir2';
-        super();
-      }
       disconnectedCallback() {
         removed = true;
       }
@@ -383,10 +331,6 @@ suite('customElements', function() {
 
     ready = inserted = removed = false;
     class XBooBoo extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-booboo-ir2';
-        super();
-      }
       disconnectedCallback() {
         removed = true;
       }
@@ -405,7 +349,6 @@ suite('customElements', function() {
   test('node.cloneNode does not upgrade until attach', function(done) {
     class XBoo extends HTMLElement {
       constructor() {
-        customElements.currentTag = 'x-boo-clone';
         super();
         this.__ready__ = true;
       }
@@ -426,7 +369,6 @@ suite('customElements', function() {
   test('document.importNode upgrades', function() {
     class XImport extends HTMLElement {
       constructor() {
-        customElements.currentTag = 'x-import';
         super();
         this.__ready__ = true;
       }
@@ -449,7 +391,6 @@ suite('customElements', function() {
     var tagName = 'x-entered-left';
     class XEnteredLeft extends HTMLElement {
       constructor() {
-        customElements.currentTag = tagName;
         super();
         invocations.push('constructor');
       }
@@ -484,10 +425,6 @@ suite('customElements', function() {
     var log = [];
 
     class XOrdering extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-ordering';
-        super();
-      }
       connectedCallback() {
         log.push(this.id);
       }
@@ -511,10 +448,6 @@ suite('customElements', function() {
   test('attached and detached in same turn', function(done) {
     var log = [];
     class XAD extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-ad';
-        super();
-      }
       connectedCallback() {
         log.push('attached');
       }
@@ -535,10 +468,6 @@ suite('customElements', function() {
   test('detached and re-attached in same turn', function(done) {
     var log = [];
     class XDA extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-da';
-        super();
-      }
       connectedCallback() {
         log.push('attached');
       }
@@ -561,10 +490,6 @@ suite('customElements', function() {
   test('disconnectedCallback ordering', function() {
     var log = [];
     class XOrdering2 extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-ordering2';
-        super();
-      }
       disconnectedCallback() {
         log.push(this.id);
       }
@@ -587,12 +512,7 @@ suite('customElements', function() {
   });
 
   test('instanceof', function() {
-    class XInstance extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'x-instance';
-        super();
-      }
-    }
+    class XInstance extends HTMLElement {}
     customElements.define('x-instance', XInstance);
     var x = document.createElement('x-instance');
     assert.instanceOf(x, XInstance, 'instanceof failed for x-instance');
@@ -600,12 +520,7 @@ suite('customElements', function() {
     x = document.createElementNS(HTMLNS, 'x-instance');
     assert.instanceOf(x, XInstance, 'instanceof failed for x-instance');
 
-    class XInstance2 extends XInstance {
-      constructor() {
-        customElements.currentTag = 'x-instance2';
-        super();
-      }
-    }
+    class XInstance2 extends XInstance {}
     customElements.define('x-instance2', XInstance2);
 
     var x2 = document.createElement('x-instance2');

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -508,133 +508,112 @@ suite('customElements', function() {
     assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
   });
 
-  // test('attached and detached in same turn', function(done) {
-  //   var log = [];
-  //   var p = Object.create(HTMLElement.prototype);
-  //   p.connectedCallback = function() {
-  //     log.push('attached');
-  //   };
-  //   p.disconnectedCallback = function() {
-  //     log.push('detached');
-  //   };
-  //   document.registerElement('x-ad', {prototype: p});
-  //   var el = document.createElement('x-ad');
-  //   work.appendChild(el);
-  //   work.removeChild(el);
-  //   setTimeout(function() {
-  //     assert.deepEqual(['attached', 'detached'], log);
-  //     done();
-  //   });
-  // });
-  //
-  // test('detached and re-attached in same turn', function(done) {
-  //   var log = [];
-  //   var p = Object.create(HTMLElement.prototype);
-  //   p.connectedCallback = function() {
-  //     log.push('attached');
-  //   };
-  //   p.disconnectedCallback = function() {
-  //     log.push('detached');
-  //   };
-  //   document.registerElement('x-da', {prototype: p});
-  //   var el = document.createElement('x-da');
-  //   work.appendChild(el);
-  //   CustomElements.takeRecords();
-  //   log = [];
-  //   work.removeChild(el);
-  //   work.appendChild(el);
-  //   setTimeout(function() {
-  //     assert.deepEqual(['detached', 'attached'], log);
-  //     done();
-  //   });
-  // });
-  //
-  // test('disconnectedCallback ordering', function() {
-  //   var log = [];
-  //   var p = Object.create(HTMLElement.prototype);
-  //   p.disconnectedCallback = function() {
-  //    log.push(this.id);
-  //   };
-  //   document.registerElement('x-boo2-ordering', {prototype: p});
-  //
-  //   work.innerHTML =
-  //       '<x-boo2-ordering id=a>' +
-  //         '<x-boo2-ordering id=b></x-boo2-ordering>' +
-  //         '<x-boo2-ordering id=c>' +
-  //           '<x-boo2-ordering id=d></x-boo2-ordering>' +
-  //           '<x-boo2-ordering id=e></x-boo2-ordering>' +
-  //         '</x-boo2-ordering>' +
-  //       '</x-boo2-ordering>';
-  //
-  //     CustomElements.takeRecords();
-  //     work.removeChild(work.firstElementChild);
-  //     CustomElements.takeRecords();
-  //     assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
-  // });
-  //
-  // test('instanceof', function() {
-  //   var p = Object.create(HTMLElement.prototype);
-  //   var PCtor = document.registerElement('x-instance', {prototype: p});
-  //   var x = document.createElement('x-instance');
-  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-instance');
-  //   x = document.createElementNS(HTMLNS, 'x-instance');
-  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-instance');
-  //
-  //   var p2 = Object.create(PCtor.prototype);
-  //   var P2Ctor = document.registerElement('x-instance2', {prototype: p2});
-  //   var x2 = document.createElement('x-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-instance2');
-  //   x2 = document.createElementNS(HTMLNS, 'x-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-instance2');
-  // });
-  //
-  //
-  // test('instanceof typeExtension', function() {
-  //   var p = Object.create(HTMLButtonElement.prototype);
-  //   var PCtor = document.registerElement('x-button-instance', {prototype: p, extends: 'button'});
-  //   var x = document.createElement('button', 'x-button-instance');
-  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-button-instance');
-  //   assert.isTrue(CustomElements.instanceof(x, HTMLButtonElement), 'instanceof failed for x-button-instance');
-  //   x = document.createElementNS(HTMLNS, 'button', 'x-button-instance');
-  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-button-instance');
-  //   assert.isTrue(CustomElements.instanceof(x, HTMLButtonElement), 'instanceof failed for x-button-instance');
-  //
-  //   var p2 = Object.create(PCtor.prototype);
-  //   var P2Ctor = document.registerElement('x-button-instance2', {prototype: p2, extends: 'button'});
-  //   var x2 = document.createElement('button','x-button-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-button-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-button-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, HTMLButtonElement), 'instanceof failed for x-button-instance2');
-  //   x2 = document.createElementNS(HTMLNS, 'button','x-button-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-button-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-button-instance2');
-  //   assert.isTrue(CustomElements.instanceof(x2, HTMLButtonElement), 'instanceof failed for x-button-instance2');
-  // });
-  //
-  // test('extends and prototype mismatch', function() {
-  //   var p = Object.create(HTMLElement.prototype);
-  //   var PCtor = document.registerElement('not-button', {
-  //     extends: 'button',
-  //     prototype: p
-  //   });
-  //
-  //   var e = document.createElement('button', 'not-button');
-  //
-  //   // NOTE: firefox has a hack for instanceof that uses element tagname mapping
-  //   // Work around by checking prototype manually
-  //   //
-  //   var ff = document.createElement('button'); ff.__proto__ = null;
-  //   if (ff instanceof HTMLButtonElement) {
-  //     // Base proto will be one below custom proto
-  //     var proto = e.__proto__.__proto__;
-  //     assert.isFalse(proto === HTMLButtonElement.prototype);
-  //     assert.isTrue(proto === HTMLElement.prototype);
-  //   } else {
-  //     assert.isFalse(CustomElements.instanceof(e, HTMLButtonElement));
-  //     assert.isTrue(CustomElements.instanceof(e, HTMLElement));
-  //   }
-  // });
+  test('attached and detached in same turn', function(done) {
+    var log = [];
+    class XAD extends HTMLElement {
+      constructor() {
+        customElements.setCurrentTag('x-ad');
+        super();
+      }
+      connectedCallback() {
+        log.push('attached');
+      }
+      disconnectedCallback() {
+        log.push('detached');
+      }
+    }
+
+    customElements.define('x-ad', XAD);
+    var el = document.createElement('x-ad');
+    work.appendChild(el);
+    work.removeChild(el);
+    customElements.flush();
+    assert.deepEqual(['attached', 'detached'], log);
+    done();
+  });
+
+  test('detached and re-attached in same turn', function(done) {
+    var log = [];
+    class XDA extends HTMLElement {
+      constructor() {
+        customElements.setCurrentTag('x-da');
+        super();
+      }
+      connectedCallback() {
+        log.push('attached');
+      }
+      disconnectedCallback() {
+        log.push('detached');
+      }
+    }
+    customElements.define('x-da', XDA);
+    var el = document.createElement('x-da');
+    work.appendChild(el);
+    customElements.flush();
+    log = [];
+    work.removeChild(el);
+    work.appendChild(el);
+    customElements.flush();
+    assert.deepEqual(['detached', 'attached'], log);
+    done();
+  });
+
+  test('disconnectedCallback ordering', function() {
+    var log = [];
+    class XOrdering2 extends HTMLElement {
+      constructor() {
+        customElements.setCurrentTag('x-ordering2');
+        super();
+      }
+      disconnectedCallback() {
+        log.push(this.id);
+      }
+    }
+    customElements.define('x-ordering2', XOrdering2);
+
+    work.innerHTML =
+        '<x-ordering2 id=a>' +
+          '<x-ordering2 id=b></x-ordering2>' +
+          '<x-ordering2 id=c>' +
+            '<x-ordering2 id=d></x-ordering2>' +
+            '<x-ordering2 id=e></x-ordering2>' +
+          '</x-ordering2>' +
+        '</x-ordering2>';
+
+      customElements.flush();
+      work.removeChild(work.firstElementChild);
+      customElements.flush();
+      assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
+  });
+
+  test('instanceof', function() {
+    class XInstance extends HTMLElement {
+      constructor() {
+        customElements.setCurrentTag('x-instance');
+        super();
+      }
+    }
+    customElements.define('x-instance', XInstance);
+    var x = document.createElement('x-instance');
+    assert.instanceOf(x, XInstance, 'instanceof failed for x-instance');
+
+    x = document.createElementNS(HTMLNS, 'x-instance');
+    assert.instanceOf(x, XInstance, 'instanceof failed for x-instance');
+
+    class XInstance2 extends XInstance {
+      constructor() {
+        customElements.setCurrentTag('x-instance2');
+        super();
+      }
+    }
+    customElements.define('x-instance2', XInstance2);
+
+    var x2 = document.createElement('x-instance2');
+    assert.instanceOf(x2, XInstance2, 'instanceof failed for x-instance2');
+    assert.instanceOf(x2, XInstance, 'instanceof failed for x-instance2');
+    x2 = document.createElementNS(HTMLNS, 'x-instance2');
+    assert.instanceOf(x2, XInstance2, 'instanceof failed for x-instance2');
+    assert.instanceOf(x2, XInstance, 'instanceof failed for x-instance2');
+  });
 
 });

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -67,7 +67,7 @@ suite('customElements', function() {
   test('customElements.define create via new', function() {
     class XFoo extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-foo');
+        customElements.setCurrentTag('x-foo');
         super();
       }
     }
@@ -90,13 +90,13 @@ suite('customElements', function() {
   test('customElements.define create subclass via new', function() {
     class XSuper1 extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-super-1');
+        customElements.setCurrentTag('x-super-1');
         super();
       }
     }
     class XSub1 extends XSuper1 {
       constructor() {
-        CustomElements.setCurrentTag('x-sub-1');
+        customElements.setCurrentTag('x-sub-1');
         super();
       }
     }
@@ -118,7 +118,7 @@ suite('customElements', function() {
 
   test('customElements.define create ES5 via new', function() {
     function XFooES5() {
-      CustomElements.setCurrentTag('x-foo-es5');
+      customElements.setCurrentTag('x-foo-es5');
       // Note the return is super (ahem) important!
       return HTMLElement.call(this);
     }
@@ -137,7 +137,7 @@ suite('customElements', function() {
   test('customElements.define create via createElement', function() {
     class XFoo2 extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-foo');
+        customElements.setCurrentTag('x-foo');
         super();
       }
     }
@@ -158,13 +158,13 @@ suite('customElements', function() {
   test('customElements.define create subclass via createElement', function() {
     class XSuper2 extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-super-1');
+        customElements.setCurrentTag('x-super-1');
         super();
       }
     }
     class XSub2 extends XSuper2 {
       constructor() {
-        CustomElements.setCurrentTag('x-sub-1');
+        customElements.setCurrentTag('x-sub-1');
         super();
       }
     }
@@ -187,7 +187,7 @@ suite('customElements', function() {
 
   test('customElements.define create ES5 via createElement', function() {
     function XBarES5() {
-      CustomElements.setCurrentTag('x-bar-es5');
+      customElements.setCurrentTag('x-bar-es5');
       return HTMLElement.call(this);
     }
     XBarES5.prototype = Object.create(HTMLElement.prototype);
@@ -205,7 +205,7 @@ suite('customElements', function() {
   test('customElements.define create via createElementNS', function() {
     class XFoo3 extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-foo3');
+        customElements.setCurrentTag('x-foo3');
         super();
       }
     }
@@ -222,7 +222,7 @@ suite('customElements', function() {
   test('customElements.define treats names as case insensitive', function() {
     class XCase extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-case');
+        customElements.setCurrentTag('x-case');
         super();
         this.isXCase = true;
       }
@@ -266,7 +266,7 @@ suite('customElements', function() {
     var count = 0;
     class XConstructor extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-constructor');
+        customElements.setCurrentTag('x-constructor');
         super();
         count++;
       }
@@ -279,7 +279,7 @@ suite('customElements', function() {
   test('customElements.define [attached|detached]Callbacks', function(done) {
     class XCallbacks extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-callbacks');
+        customElements.setCurrentTag('x-callbacks');
         super();
         this.attached = false;
         this.detached = false;
@@ -299,12 +299,12 @@ suite('customElements', function() {
     assert.isFalse(e.detached);
 
     work.appendChild(e);
-    CustomElements.flush();
+    customElements.flush();
     assert.isTrue(e.attached);
     assert.isFalse(e.detached);
 
     work.removeChild(e);
-    CustomElements.flush();
+    customElements.flush();
     assert.isTrue(e.attached);
     assert.isTrue(e.detached);
 
@@ -319,7 +319,7 @@ suite('customElements', function() {
       }
 
       constructor() {
-        CustomElements.setCurrentTag('x-boo-acp');
+        customElements.setCurrentTag('x-boo-acp');
         super();
       }
       attributeChangedCallback(inName, inOldValue) {
@@ -339,7 +339,7 @@ suite('customElements', function() {
     var inserted = 0;
     class XBoo extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-boo-at');
+        customElements.setCurrentTag('x-boo-at');
         super();
       }
       connectedCallback() {
@@ -350,13 +350,13 @@ suite('customElements', function() {
     var xboo = new XBoo();
     assert.equal(inserted, 0, 'inserted must be 0');
     work.appendChild(xboo);
-    CustomElements.flush();
+    customElements.flush();
     assert.equal(inserted, 1, 'inserted must be 1');
     work.removeChild(xboo);
-    CustomElements.flush();
+    customElements.flush();
     assert(!xboo.parentNode);
     work.appendChild(xboo);
-    CustomElements.flush();
+    customElements.flush();
     assert.equal(inserted, 2, 'inserted must be 2');
     done();
   });
@@ -365,7 +365,7 @@ suite('customElements', function() {
     var ready, inserted, removed;
     class XBoo extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-boo-ir2');
+        customElements.setCurrentTag('x-boo-ir2');
         super();
       }
       disconnectedCallback() {
@@ -376,15 +376,15 @@ suite('customElements', function() {
     var xboo = new XBoo();
     assert(!removed, 'removed must be false [XBoo]');
     work.appendChild(xboo);
-    CustomElements.flush();
+    customElements.flush();
     work.removeChild(xboo);
-    CustomElements.flush();
+    customElements.flush();
     assert(removed, 'removed must be true [XBoo]');
 
     ready = inserted = removed = false;
     class XBooBoo extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-booboo-ir2');
+        customElements.setCurrentTag('x-booboo-ir2');
         super();
       }
       disconnectedCallback() {
@@ -395,9 +395,9 @@ suite('customElements', function() {
     var xbooboo = new XBooBoo();
     assert(!removed, 'removed must be false [XBooBoo]');
     work.appendChild(xbooboo);
-    CustomElements.flush();
+    customElements.flush();
     work.removeChild(xbooboo);
-    CustomElements.flush();
+    customElements.flush();
     assert(removed, 'removed must be true [XBooBoo]');
     done();
   });
@@ -423,7 +423,7 @@ suite('customElements', function() {
   test('node.cloneNode does not upgrade until attach', function(done) {
     class XBoo extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-boo-clone');
+        customElements.setCurrentTag('x-boo-clone');
         super();
         this.__ready__ = true;
       }
@@ -431,12 +431,12 @@ suite('customElements', function() {
     customElements.define('x-boo-clone', XBoo);
     var xboo = new XBoo();
     work.appendChild(xboo);
-    CustomElements.flush();
+    customElements.flush();
     var xboo2 = xboo.cloneNode(true);
-    CustomElements.flush();
+    customElements.flush();
     assert.isNotOk(xboo2.__ready__, 'clone createdCallback must be called');
     work.appendChild(xboo2);
-    CustomElements.flush();
+    customElements.flush();
     assert.isTrue(xboo2.__ready__, 'clone createdCallback must be called');
     done();
   });
@@ -444,7 +444,7 @@ suite('customElements', function() {
   test('document.importNode upgrades', function() {
     class XImport extends HTMLElement {
       constructor() {
-        CustomElements.setCurrentTag('x-import');
+        customElements.setCurrentTag('x-import');
         super();
         this.__ready__ = true;
       }
@@ -458,7 +458,7 @@ suite('customElements', function() {
     var importedEl = imported.firstChild;
     assert.isNotOk(importedEl.__ready__, 'imported element upgraded');
     work.appendChild(imported);
-    CustomElements.flush();
+    customElements.flush();
     assert.isOk(importedEl.__ready__, 'imported element upgraded');
   });
 

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -67,7 +67,7 @@ suite('customElements', function() {
   test('customElements.define create via new', function() {
     class XFoo extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-foo');
+        customElements.currentTag = 'x-foo';
         super();
       }
     }
@@ -90,13 +90,13 @@ suite('customElements', function() {
   test('customElements.define create subclass via new', function() {
     class XSuper1 extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-super-1');
+        customElements.currentTag = 'x-super-1';
         super();
       }
     }
     class XSub1 extends XSuper1 {
       constructor() {
-        customElements.setCurrentTag('x-sub-1');
+        customElements.currentTag = 'x-sub-1';
         super();
       }
     }
@@ -118,7 +118,7 @@ suite('customElements', function() {
 
   test('customElements.define create ES5 via new', function() {
     function XFooES5() {
-      customElements.setCurrentTag('x-foo-es5');
+      customElements.currentTag = 'x-foo-es5';
       // Note the return is super (ahem) important!
       return HTMLElement.call(this);
     }
@@ -137,7 +137,7 @@ suite('customElements', function() {
   test('customElements.define create via createElement', function() {
     class XFoo2 extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-foo');
+        customElements.currentTag = 'x-foo';
         super();
       }
     }
@@ -158,13 +158,13 @@ suite('customElements', function() {
   test('customElements.define create subclass via createElement', function() {
     class XSuper2 extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-super-1');
+        customElements.currentTag = 'x-super-1';
         super();
       }
     }
     class XSub2 extends XSuper2 {
       constructor() {
-        customElements.setCurrentTag('x-sub-1');
+        customElements.currentTag = 'x-sub-1';
         super();
       }
     }
@@ -187,7 +187,7 @@ suite('customElements', function() {
 
   test('customElements.define create ES5 via createElement', function() {
     function XBarES5() {
-      customElements.setCurrentTag('x-bar-es5');
+      customElements.currentTag = 'x-bar-es5';
       return HTMLElement.call(this);
     }
     XBarES5.prototype = Object.create(HTMLElement.prototype);
@@ -205,7 +205,7 @@ suite('customElements', function() {
   test('customElements.define create via createElementNS', function() {
     class XFoo3 extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-foo3');
+        customElements.currentTag = 'x-foo3';
         super();
       }
     }
@@ -222,7 +222,7 @@ suite('customElements', function() {
   test('customElements.define treats names as case insensitive', function() {
     class XCase extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-case');
+        customElements.currentTag = 'x-case';
         super();
         this.isXCase = true;
       }
@@ -266,7 +266,7 @@ suite('customElements', function() {
     var count = 0;
     class XConstructor extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-constructor');
+        customElements.currentTag = 'x-constructor';
         super();
         count++;
       }
@@ -279,7 +279,7 @@ suite('customElements', function() {
   test('customElements.define [attached|detached]Callbacks', function(done) {
     class XCallbacks extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-callbacks');
+        customElements.currentTag = 'x-callbacks';
         super();
         this.attached = false;
         this.detached = false;
@@ -319,11 +319,11 @@ suite('customElements', function() {
       }
 
       constructor() {
-        customElements.setCurrentTag('x-boo-acp');
+        customElements.currentTag = 'x-boo-acp';
         super();
       }
       attributeChangedCallback(inName, inOldValue) {
-        if (inName == 'foo' && inOldValue=='bar'
+        if (inName == 'foo' && inOldValue == 'bar'
             && this.attributes.foo.value == 'zot') {
           done();
         }
@@ -339,7 +339,7 @@ suite('customElements', function() {
     var inserted = 0;
     class XBoo extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-boo-at');
+        customElements.currentTag = 'x-boo-at';
         super();
       }
       connectedCallback() {
@@ -365,7 +365,7 @@ suite('customElements', function() {
     var ready, inserted, removed;
     class XBoo extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-boo-ir2');
+        customElements.currentTag = 'x-boo-ir2';
         super();
       }
       disconnectedCallback() {
@@ -384,7 +384,7 @@ suite('customElements', function() {
     ready = inserted = removed = false;
     class XBooBoo extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-booboo-ir2');
+        customElements.currentTag = 'x-booboo-ir2';
         super();
       }
       disconnectedCallback() {
@@ -405,7 +405,7 @@ suite('customElements', function() {
   test('node.cloneNode does not upgrade until attach', function(done) {
     class XBoo extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-boo-clone');
+        customElements.currentTag = 'x-boo-clone';
         super();
         this.__ready__ = true;
       }
@@ -426,7 +426,7 @@ suite('customElements', function() {
   test('document.importNode upgrades', function() {
     class XImport extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-import');
+        customElements.currentTag = 'x-import';
         super();
         this.__ready__ = true;
       }
@@ -449,7 +449,7 @@ suite('customElements', function() {
     var tagName = 'x-entered-left';
     class XEnteredLeft extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag(tagName);
+        customElements.currentTag = tagName;
         super();
         invocations.push('constructor');
       }
@@ -485,7 +485,7 @@ suite('customElements', function() {
 
     class XOrdering extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-ordering');
+        customElements.currentTag = 'x-ordering';
         super();
       }
       connectedCallback() {
@@ -512,7 +512,7 @@ suite('customElements', function() {
     var log = [];
     class XAD extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-ad');
+        customElements.currentTag = 'x-ad';
         super();
       }
       connectedCallback() {
@@ -536,7 +536,7 @@ suite('customElements', function() {
     var log = [];
     class XDA extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-da');
+        customElements.currentTag = 'x-da';
         super();
       }
       connectedCallback() {
@@ -562,7 +562,7 @@ suite('customElements', function() {
     var log = [];
     class XOrdering2 extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-ordering2');
+        customElements.currentTag = 'x-ordering2';
         super();
       }
       disconnectedCallback() {
@@ -589,7 +589,7 @@ suite('customElements', function() {
   test('instanceof', function() {
     class XInstance extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('x-instance');
+        customElements.currentTag = 'x-instance';
         super();
       }
     }
@@ -602,7 +602,7 @@ suite('customElements', function() {
 
     class XInstance2 extends XInstance {
       constructor() {
-        customElements.setCurrentTag('x-instance2');
+        customElements.currentTag = 'x-instance2';
         super();
       }
     }

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -22,49 +22,49 @@ suite('customElements', function() {
     document.body.removeChild(work);
   });
 
-  test('document.defineElement exists', function() {
-    assert.isFunction(document.defineElement);
+  test('customElements.define exists', function() {
+    assert.isFunction(customElements.define);
   });
 
-  test('document.defineElement requires name argument', function() {
+  test('customElements.define requires name argument', function() {
     assert.throws(function() {
-      document.defineElement();
-    }, '', 'document.defineElement failed to throw when given no arguments');
+      customElements.define();
+    }, '', 'customElements.define failed to throw when given no arguments');
   });
 
-  test('document.defineElement requires name argument to contain a dash', function() {
+  test('customElements.define requires name argument to contain a dash', function() {
     assert.throws(function () {
-      document.defineElement('xfoo', {prototype: Object.create(HTMLElement.prototype)});
-    }, '', 'document.defineElement failed to throw when given no arguments');
+      customElements.define('xfoo', {prototype: Object.create(HTMLElement.prototype)});
+    }, '', 'customElements.define failed to throw when given no arguments');
   });
 
-  test('document.defineElement second argument is not optional', function() {
+  test('customElements.define second argument is not optional', function() {
     assert.throws(function () {
-      document.defineElement('x-no-options');
-    }, '', 'document.defineElement failed to function without ElementRegistionOptions argument');
+      customElements.define('x-no-options');
+    }, '', 'customElements.define failed to function without ElementRegistionOptions argument');
   });
 
-  test('document.defineElement second argument prototype property is not optional', function() {
+  test('customElements.define second argument prototype property is not optional', function() {
     assert.throws(function () {
-      document.defineElement('x-no-proto', {});
-    }, '', 'document.defineElement failed to function without ElementRegistionOptions prototype property');
+      customElements.define('x-no-proto', {});
+    }, '', 'customElements.define failed to function without ElementRegistionOptions prototype property');
   });
 
-  test('document.defineElement requires name argument to not conflict with a reserved name', function() {
+  test('customElements.define requires name argument to not conflict with a reserved name', function() {
     assert.throws(function() {
-      document.defineElement('font-face', {prototype: Object.create(HTMLElement.prototype)});
+      customElements.define('font-face', {prototype: Object.create(HTMLElement.prototype)});
     }, '', 'Failed to execute \'defineElement\' on \'Document\': Registration failed for type \'font-face\'. The type name is invalid.');
   });
 
-  test('document.defineElement requires name argument to be unique', function() {
+  test('customElements.define requires name argument to be unique', function() {
     class XDuplicate extends HTMLElement {}
-    document.defineElement('x-duplicate', XDuplicate);
+    customElements.define('x-duplicate', XDuplicate);
     assert.throws(function() {
-      document.defineElement('x-duplicate', XDuplicate);
-    }, '', 'document.defineElement failed to throw when called multiple times with the same element name');
+      customElements.define('x-duplicate', XDuplicate);
+    }, '', 'customElements.define failed to throw when called multiple times with the same element name');
   });
 
-  test('document.defineElement create via new', function() {
+  test('customElements.define create via new', function() {
     class XFoo extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-foo');
@@ -72,7 +72,7 @@ suite('customElements', function() {
       }
     }
     // register x-foo
-    document.defineElement('x-foo', XFoo);
+    customElements.define('x-foo', XFoo);
     // create an instance via new
     var xfoo = new XFoo();
     // test localName
@@ -87,7 +87,7 @@ suite('customElements', function() {
     assert.equal(xfoo.textContent, '[x-foo]');
   });
 
-  test('document.defineElement create subclass via new', function() {
+  test('customElements.define create subclass via new', function() {
     class XSuper1 extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-super-1');
@@ -100,8 +100,8 @@ suite('customElements', function() {
         super();
       }
     }
-    document.defineElement('x-super-1', XSuper1);
-    document.defineElement('x-sub-1', XSub1);
+    customElements.define('x-super-1', XSuper1);
+    customElements.define('x-sub-1', XSub1);
 
     // create an instance via new
     var xsuper = new XSuper1();
@@ -116,7 +116,7 @@ suite('customElements', function() {
     assert.instanceOf(xsub, XSub1);
   });
 
-  test('document.defineElement create ES5 via new', function() {
+  test('customElements.define create ES5 via new', function() {
     function XFooES5() {
       CustomElements.setCurrentTag('x-foo-es5');
       // Note the return is super (ahem) important!
@@ -125,7 +125,7 @@ suite('customElements', function() {
     XFooES5.prototype = Object.create(HTMLElement.prototype);
     XFooES5.prototype.constructor = XFooES5;
     // register x-foo
-    document.defineElement('x-foo-es5', XFooES5);
+    customElements.define('x-foo-es5', XFooES5);
     // create an instance via new
     var xfoo = new XFooES5();
     // test localName
@@ -134,7 +134,7 @@ suite('customElements', function() {
     assert.instanceOf(xfoo, XFooES5);
   });
 
-  test('document.defineElement create via createElement', function() {
+  test('customElements.define create via createElement', function() {
     class XFoo2 extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-foo');
@@ -142,7 +142,7 @@ suite('customElements', function() {
       }
     }
     // register x-foo
-    var XFoo = document.defineElement('x-foo2', XFoo2);
+    var XFoo = customElements.define('x-foo2', XFoo2);
     // create an instance via createElement
     var xfoo = document.createElement('x-foo2');
     // test localName
@@ -155,7 +155,7 @@ suite('customElements', function() {
     assert.equal(xfoo.textContent, '[x-foo2]');
   });
 
-  test('document.defineElement create subclass via createElement', function() {
+  test('customElements.define create subclass via createElement', function() {
     class XSuper2 extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-super-1');
@@ -168,8 +168,8 @@ suite('customElements', function() {
         super();
       }
     }
-    document.defineElement('x-super-2', XSuper2);
-    document.defineElement('x-sub-2', XSub2);
+    customElements.define('x-super-2', XSuper2);
+    customElements.define('x-sub-2', XSub2);
 
 
     // create an instance via createElement
@@ -185,7 +185,7 @@ suite('customElements', function() {
     assert.instanceOf(xsub, XSub2);
   });
 
-  test('document.defineElement create ES5 via createElement', function() {
+  test('customElements.define create ES5 via createElement', function() {
     function XBarES5() {
       CustomElements.setCurrentTag('x-bar-es5');
       return HTMLElement.call(this);
@@ -193,7 +193,7 @@ suite('customElements', function() {
     XBarES5.prototype = Object.create(HTMLElement.prototype);
     XBarES5.prototype.constructor = XBarES5;
     // register x-foo
-    document.defineElement('x-bar-es5', XBarES5);
+    customElements.define('x-bar-es5', XBarES5);
     // create an instance via createElement
     var xbar = document.createElement('x-bar-es5');
     // test localName
@@ -202,7 +202,7 @@ suite('customElements', function() {
     assert.instanceOf(xbar, XBarES5);
   });
 
-  test('document.defineElement create via createElementNS', function() {
+  test('customElements.define create via createElementNS', function() {
     class XFoo3 extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-foo3');
@@ -210,7 +210,7 @@ suite('customElements', function() {
       }
     }
     // register x-foo
-    document.defineElement('x-foo3', XFoo3);
+    customElements.define('x-foo3', XFoo3);
     // create an instance via createElementNS
     var xfoo = document.createElementNS(HTMLNS, 'x-foo3');
     // test instanceof
@@ -219,7 +219,7 @@ suite('customElements', function() {
     assert.equal(xfoo.localName, 'x-foo3');
   });
 
-  test('document.defineElement treats names as case insensitive', function() {
+  test('customElements.define treats names as case insensitive', function() {
     class XCase extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-case');
@@ -227,7 +227,7 @@ suite('customElements', function() {
         this.isXCase = true;
       }
     }
-    document.defineElement('X-CASE', XCase);
+    customElements.define('X-CASE', XCase);
     // createElement
     var x = document.createElement('X-CASE');
     assert.equal(x.isXCase, true);
@@ -248,7 +248,7 @@ suite('customElements', function() {
     // assert.equal(work.firstChild.nextSibling.isXCase, true);
   });
 
-  test('document.defineElement create multiple instances', function() {
+  test('customElements.define create multiple instances', function() {
     // create an instance
     var xfoo1 = document.createElement('x-foo');
     // create another instance
@@ -262,7 +262,7 @@ suite('customElements', function() {
     assert.equal(xfoo2.textContent, '[x-foo2]');
   });
 
-  test('document.defineElement calls constructor only once', function() {
+  test('customElements.define calls constructor only once', function() {
     var count = 0;
     class XConstructor extends HTMLElement {
       constructor() {
@@ -271,12 +271,12 @@ suite('customElements', function() {
         count++;
       }
     }
-    document.defineElement('x-constructor', XConstructor);
+    customElements.define('x-constructor', XConstructor);
     var xconstructor = new XConstructor();
     assert.equal(count, 1);
   });
 
-  test('document.defineElement [attached|detached]Callbacks', function(done) {
+  test('customElements.define [attached|detached]Callbacks', function(done) {
     class XCallbacks extends HTMLElement {
       constructor() {
         CustomElements.setCurrentTag('x-callbacks');
@@ -293,7 +293,7 @@ suite('customElements', function() {
         this.detached = true;
       }
     }
-    document.defineElement('x-callbacks', XCallbacks);
+    customElements.define('x-callbacks', XCallbacks);
     var e = new XCallbacks();
     assert.isFalse(e.attached);
     assert.isFalse(e.detached);
@@ -312,7 +312,7 @@ suite('customElements', function() {
   });
 
 
-  test('document.defineElement attributeChangedCallback in prototype', function(done) {
+  test('customElements.define attributeChangedCallback in prototype', function(done) {
     class XBoo extends HTMLElement {
       static get observedAttributes() {
         return ['foo'];
@@ -329,13 +329,13 @@ suite('customElements', function() {
         }
       }
     }
-    document.defineElement('x-boo-acp', XBoo);
+    customElements.define('x-boo-acp', XBoo);
     var xboo = new XBoo();
     xboo.setAttribute('foo', 'bar');
     xboo.setAttribute('foo', 'zot');
   });
 
-  test('document.defineElement attachedCallbacks in prototype', function(done) {
+  test('customElements.define attachedCallbacks in prototype', function(done) {
     var inserted = 0;
     class XBoo extends HTMLElement {
       constructor() {
@@ -346,7 +346,7 @@ suite('customElements', function() {
         inserted++;
       }
     }
-    document.defineElement('x-boo-at', XBoo);
+    customElements.define('x-boo-at', XBoo);
     var xboo = new XBoo();
     assert.equal(inserted, 0, 'inserted must be 0');
     work.appendChild(xboo);
@@ -372,7 +372,7 @@ suite('customElements', function() {
         removed = true;
       }
     }
-    document.defineElement('x-boo-ir2', XBoo);
+    customElements.define('x-boo-ir2', XBoo);
     var xboo = new XBoo();
     assert(!removed, 'removed must be false [XBoo]');
     work.appendChild(xboo);
@@ -391,7 +391,7 @@ suite('customElements', function() {
         removed = true;
       }
     }
-    document.defineElement('x-booboo-ir2', XBooBoo);
+    customElements.define('x-booboo-ir2', XBooBoo);
     var xbooboo = new XBooBoo();
     assert(!removed, 'removed must be false [XBooBoo]');
     work.appendChild(xbooboo);
@@ -428,7 +428,7 @@ suite('customElements', function() {
         this.__ready__ = true;
       }
     }
-    document.defineElement('x-boo-clone', XBoo);
+    customElements.define('x-boo-clone', XBoo);
     var xboo = new XBoo();
     work.appendChild(xboo);
     CustomElements.flush();
@@ -449,7 +449,7 @@ suite('customElements', function() {
         this.__ready__ = true;
       }
     }
-    document.defineElement('x-import', XImport);
+    customElements.define('x-import', XImport);
     var frag = document.createDocumentFragment();
     frag.appendChild(document.createElement('x-import'));
     assert.isTrue(frag.firstChild.__ready__, 'source element upgraded');

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -116,6 +116,25 @@ suite('customElements', function() {
     assert.instanceOf(xsub, XSub1);
   });
 
+  test('document.defineElement create ES5 via new', function() {
+    function XFooES5() {
+      CustomElements.setCurrentTag('x-foo-es5');
+      // Note the return is super (ahem) important!
+      return HTMLElement.call(this);
+    }
+    XFooES5.prototype = Object.create(HTMLElement.prototype);
+    XFooES5.prototype.constructor = XFooES5;
+    // register x-foo
+    document.defineElement('x-foo-es5', XFooES5);
+    // create an instance via new
+    var xfoo = new XFooES5();
+    console.log(xfoo);
+    // test localName
+    assert.equal(xfoo.localName, 'x-foo-es5');
+    // test instanceof
+    assert.instanceOf(xfoo, XFooES5);
+  });
+
   test('document.defineElement create via createElement', function() {
     class XFoo2 extends HTMLElement {
       constructor() {
@@ -165,6 +184,24 @@ suite('customElements', function() {
     // test instanceof
     assert.instanceOf(xsuper, XSuper2);
     assert.instanceOf(xsub, XSub2);
+  });
+
+  test('document.defineElement create ES5 via createElement', function() {
+    function XBarES5() {
+      CustomElements.setCurrentTag('x-bar-es5');
+      return HTMLElement.call(this);
+    }
+    XBarES5.prototype = Object.create(HTMLElement.prototype);
+    XBarES5.prototype.constructor = XBarES5;
+    // register x-foo
+    document.defineElement('x-bar-es5', XBarES5);
+    // create an instance via createElement
+    var xbar = document.createElement('x-bar-es5');
+    console.log(xbar);
+    // test localName
+    assert.equal(xbar.localName, 'x-bar-es5');
+    // test instanceof
+    assert.instanceOf(xbar, XBarES5);
   });
 
   // test('document.registerElement create via createElementNS', function() {

--- a/tests/CustomElements/v1/js/customElements.js
+++ b/tests/CustomElements/v1/js/customElements.js
@@ -1,0 +1,669 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('customElements', function() {
+  var work;
+  var assert = chai.assert;
+  var HTMLNS = 'http://www.w3.org/1999/xhtml';
+
+  setup(function() {
+    work = document.createElement('div');
+    document.body.appendChild(work);
+  });
+
+  teardown(function() {
+    document.body.removeChild(work);
+  });
+
+  test('document.defineElement exists', function() {
+    assert.isFunction(document.defineElement);
+  });
+
+  test('document.defineElement requires name argument', function() {
+    assert.throws(function() {
+      document.defineElement();
+    }, '', 'document.defineElement failed to throw when given no arguments');
+  });
+
+  test('document.defineElement requires name argument to contain a dash', function() {
+    assert.throws(function () {
+      document.defineElement('xfoo', {prototype: Object.create(HTMLElement.prototype)});
+    }, '', 'document.defineElement failed to throw when given no arguments');
+  });
+
+  test('document.defineElement second argument is not optional', function() {
+    assert.throws(function () {
+      document.defineElement('x-no-options');
+    }, '', 'document.defineElement failed to function without ElementRegistionOptions argument');
+  });
+
+  test('document.defineElement second argument prototype property is not optional', function() {
+    assert.throws(function () {
+      document.defineElement('x-no-proto', {});
+    }, '', 'document.defineElement failed to function without ElementRegistionOptions prototype property');
+  });
+
+  test('document.defineElement requires name argument to not conflict with a reserved name', function() {
+    assert.throws(function() {
+      document.defineElement('font-face', {prototype: Object.create(HTMLElement.prototype)});
+    }, '', 'Failed to execute \'defineElement\' on \'Document\': Registration failed for type \'font-face\'. The type name is invalid.');
+  });
+
+  test('document.defineElement requires name argument to be unique', function() {
+    class XDuplicate extends HTMLElement {}
+    document.defineElement('x-duplicate', XDuplicate);
+    assert.throws(function() {
+      document.defineElement('x-duplicate', XDuplicate);
+    }, '', 'document.defineElement failed to throw when called multiple times with the same element name');
+  });
+
+  test('document.defineElement create via new', function() {
+    class XFoo extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-foo');
+        super();
+      }
+    }
+    // register x-foo
+    document.defineElement('x-foo', XFoo);
+    // create an instance via new
+    var xfoo = new XFoo();
+    // test localName
+    assert.equal(xfoo.localName, 'x-foo');
+    // test instanceof
+    assert.instanceOf(xfoo, XFoo);
+    // attach content
+    work.appendChild(xfoo).textContent = '[x-foo]';
+    // reacquire
+    var xfoo = work.querySelector('x-foo');
+    // test textContent
+    assert.equal(xfoo.textContent, '[x-foo]');
+  });
+
+  test('document.defineElement create subclass via new', function() {
+    class XSuper1 extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-super-1');
+        super();
+      }
+    }
+    class XSub1 extends XSuper1 {
+      constructor() {
+        CustomElements.setCurrentTag('x-sub-1');
+        super();
+      }
+    }
+    document.defineElement('x-super-1', XSuper1);
+    document.defineElement('x-sub-1', XSub1);
+
+    // create an instance via new
+    var xsuper = new XSuper1();
+    var xsub = new XSub1();
+
+    // test localName
+    assert.equal(xsuper.localName, 'x-super-1');
+    assert.equal(xsub.localName, 'x-sub-1');
+
+    // test instanceof
+    assert.instanceOf(xsuper, XSuper1);
+    assert.instanceOf(xsub, XSub1);
+  });
+
+  test('document.defineElement create via createElement', function() {
+    class XFoo2 extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-foo');
+        super();
+      }
+    }
+    // register x-foo
+    var XFoo = document.defineElement('x-foo2', XFoo2);
+    // create an instance via createElement
+    var xfoo = document.createElement('x-foo2');
+    // test localName
+    assert.equal(xfoo.localName, 'x-foo2');
+    // test instanceof
+    assert.instanceOf(xfoo, XFoo2);
+    // attach content
+    xfoo.textContent = '[x-foo2]';
+    // test textContent
+    assert.equal(xfoo.textContent, '[x-foo2]');
+  });
+
+  test('document.defineElement create subclass via createElement', function() {
+    class XSuper2 extends HTMLElement {
+      constructor() {
+        CustomElements.setCurrentTag('x-super-1');
+        super();
+      }
+    }
+    class XSub2 extends XSuper2 {
+      constructor() {
+        CustomElements.setCurrentTag('x-sub-1');
+        super();
+      }
+    }
+    document.defineElement('x-super-2', XSuper2);
+    document.defineElement('x-sub-2', XSub2);
+
+
+    // create an instance via createElement
+    var xsuper = document.createElement('x-super-2');
+    var xsub = document.createElement('x-sub-2');
+
+    // test localName
+    assert.equal(xsuper.localName, 'x-super-2');
+    assert.equal(xsub.localName, 'x-sub-2');
+
+    // test instanceof
+    assert.instanceOf(xsuper, XSuper2);
+    assert.instanceOf(xsub, XSub2);
+  });
+
+  // test('document.registerElement create via createElementNS', function() {
+  //   // create an instance via createElementNS
+  //   var xfoo = document.createElementNS(HTMLNS, 'x-foo2');
+  //   // test localName
+  //   assert.equal(xfoo.localName, 'x-foo2');
+  //   // attach content
+  //   xfoo.textContent = '[x-foo2]';
+  //   // test textContent
+  //   assert.equal(xfoo.textContent, '[x-foo2]');
+  // });
+  //
+  // test('document.registerElement treats names as case insensitive', function() {
+  //   var proto = {prototype: Object.create(HTMLElement.prototype)};
+  //   proto.prototype.isXCase = true;
+  //   var XCase = document.registerElement('X-CASE', proto);
+  //   // createElement
+  //   var x = document.createElement('X-CASE');
+  //   assert.equal(x.isXCase, true);
+  //   x = document.createElement('x-case');
+  //   assert.equal(x.isXCase, true);
+  //   // createElementNS
+  //   // NOTE: createElementNS is case sensitive, disable tests
+  //   // x = document.createElementNS(HTMLNS, 'X-CASE');
+  //   // assert.equal(x.isXCase, true);
+  //   // x = document.createElementNS(HTMLNS, 'x-case');
+  //   // assert.equal(x.isXCase, true);
+  //   // upgrade
+  //   work.innerHTML = '<X-CASE></X-CASE><x-CaSe></x-CaSe>';
+  //   CustomElements.takeRecords();
+  //   assert.equal(work.firstChild.isXCase, true);
+  //   assert.equal(work.firstChild.nextSibling.isXCase, true);
+  // });
+  //
+  // test('document.registerElement create multiple instances', function() {
+  //   var XFooPrototype = Object.create(HTMLElement.prototype);
+  //   XFooPrototype.bluate = function() {
+  //     this.color = 'lightblue';
+  //   };
+  //   var XFoo = document.registerElement('x-foo3', {
+  //     prototype: XFooPrototype
+  //   });
+  //   // create an instance
+  //   var xfoo1 = new XFoo();
+  //   // create another instance
+  //   var xfoo2 = new XFoo();
+  //   // test textContent
+  //   xfoo1.textContent = '[x-foo1]';
+  //   xfoo2.textContent = '[x-foo2]';
+  //   assert.equal(xfoo1.textContent, '[x-foo1]');
+  //   assert.equal(xfoo2.textContent, '[x-foo2]');
+  //   // test bluate
+  //   xfoo1.bluate();
+  //   assert.equal(xfoo1.color, 'lightblue');
+  //   assert.isUndefined(xfoo2.color);
+  // });
+  //
+  // test('document.registerElement extend native element', function() {
+  //   // test native element extension
+  //   var XBarPrototype = Object.create(HTMLButtonElement.prototype);
+  //   var XBar = document.registerElement('x-bar', {
+  //     prototype: XBarPrototype,
+  //     extends: 'button'
+  //   });
+  //   var xbar = new XBar();
+  //   work.appendChild(xbar).textContent = 'x-bar';
+  //   xbar = work.querySelector('button[is=x-bar]');
+  //   assert(xbar);
+  //   assert.equal(xbar.textContent, 'x-bar');
+  //   // test extension of native element extension
+  //   var XBarBarPrototype = Object.create(XBarPrototype);
+  //   var XBarBar = document.registerElement('x-barbar', {
+  //     prototype: XBarBarPrototype,
+  //     extends: 'button'
+  //   });
+  //   var xbarbar = new XBarBar();
+  //   work.appendChild(xbarbar).textContent = 'x-barbar';
+  //   xbarbar = work.querySelector('button[is=x-barbar]');
+  //   assert(xbarbar);
+  //   assert.equal(xbarbar.textContent, 'x-barbar');
+  //   // test extension^3
+  //   var XBarBarBarPrototype = Object.create(XBarBarPrototype);
+  //   var XBarBarBar = document.registerElement('x-barbarbar', {
+  //     prototype: XBarBarBarPrototype,
+  //     extends: 'button'
+  //   });
+  //   var xbarbarbar = new XBarBarBar();
+  //   work.appendChild(xbarbarbar).textContent = 'x-barbarbar';
+  //   xbarbarbar = work.querySelector('button[is=x-barbarbar]');
+  //   assert(xbarbarbar);
+  //   assert.equal(xbarbarbar.textContent, 'x-barbarbar');
+  // });
+  //
+  // test('document.registerElement with type extension treats names as case insensitive', function() {
+  //   var proto = {prototype: Object.create(HTMLButtonElement.prototype), extends: 'button'};
+  //   proto.prototype.isXCase = true;
+  //   var XCase = document.registerElement('X-EXTEND-CASE', proto);
+  //   // createElement
+  //   var x = document.createElement('button', 'X-EXTEND-CASE');
+  //   assert.equal(x.isXCase, true);
+  //   x = document.createElement('button', 'x-extend-case');
+  //   assert.equal(x.isXCase, true);
+  //   x = document.createElement('BUTTON', 'X-EXTEND-CASE');
+  //   assert.equal(x.isXCase, true);
+  //   x = document.createElement('BUTTON', 'x-extend-case');
+  //   assert.equal(x.isXCase, true);
+  //   // upgrade
+  //   work.innerHTML = '<button is="X-EXTEND-CASE"></button><button is="x-ExTeNd-CaSe"></button>';
+  //   CustomElements.takeRecords();
+  //   assert.equal(work.firstChild.isXCase, true);
+  //   assert.equal(work.firstChild.nextSibling.isXCase, true);
+  // });
+  //
+  // test('document.registerElement createdCallback in prototype', function() {
+  //   var XBooPrototype = Object.create(HTMLElement.prototype);
+  //   XBooPrototype.createdCallback = function() {
+  //     this.style.fontStyle = 'italic';
+  //   }
+  //   var XBoo = document.registerElement('x-boo', {
+  //     prototype: XBooPrototype
+  //   });
+  //   var xboo = new XBoo();
+  //   assert.equal(xboo.style.fontStyle, 'italic');
+  //   //
+  //   var XBooBooPrototype = Object.create(XBooPrototype);
+  //   XBooBooPrototype.createdCallback = function() {
+  //     XBoo.prototype.createdCallback.call(this);
+  //     this.style.fontSize = '32pt';
+  //   };
+  //   var XBooBoo = document.registerElement('x-booboo', {
+  //     prototype: XBooBooPrototype
+  //   });
+  //   var xbooboo = new XBooBoo();
+  //   assert.equal(xbooboo.style.fontStyle, 'italic');
+  //   assert.equal(xbooboo.style.fontSize, '32pt');
+  // });
+  //
+  // test('document.registerElement [created|attached|detached]Callbacks in prototype', function(done) {
+  //   var ready, inserted, removed;
+  //   var XBooPrototype = Object.create(HTMLElement.prototype);
+  //   XBooPrototype.createdCallback = function() {
+  //     ready = true;
+  //   }
+  //   XBooPrototype.attachedCallback = function() {
+  //     inserted = true;
+  //   }
+  //   XBooPrototype.detachedCallback = function() {
+  //     removed = true;
+  //   }
+  //   var XBoo = document.registerElement('x-boo-ir', {
+  //     prototype: XBooPrototype
+  //   });
+  //   var xboo = new XBoo();
+  //   assert(ready, 'ready must be true [XBoo]');
+  //   assert(!inserted, 'inserted must be false [XBoo]');
+  //   assert(!removed, 'removed must be false [XBoo]');
+  //   work.appendChild(xboo);
+  //   CustomElements.takeRecords();
+  //   assert(inserted, 'inserted must be true [XBoo]');
+  //   work.removeChild(xboo);
+  //   CustomElements.takeRecords();
+  //   assert(removed, 'removed must be true [XBoo]');
+  //   //
+  //   ready = inserted = removed = false;
+  //   var XBooBooPrototype = Object.create(XBooPrototype);
+  //   XBooBooPrototype.createdCallback = function() {
+  //     XBoo.prototype.createdCallback.call(this);
+  //   };
+  //   XBooBooPrototype.attachedCallback = function() {
+  //     XBoo.prototype.attachedCallback.call(this);
+  //   };
+  //   XBooBooPrototype.detachedCallback = function() {
+  //     XBoo.prototype.detachedCallback.call(this);
+  //   };
+  //   var XBooBoo = document.registerElement('x-booboo-ir', {
+  //     prototype: XBooBooPrototype
+  //   });
+  //   var xbooboo = new XBooBoo();
+  //   assert(ready, 'ready must be true [XBooBoo]');
+  //   assert(!inserted, 'inserted must be false [XBooBoo]');
+  //   assert(!removed, 'removed must be false [XBooBoo]');
+  //   work.appendChild(xbooboo);
+  //   CustomElements.takeRecords();
+  //   assert(inserted, 'inserted must be true [XBooBoo]');
+  //   work.removeChild(xbooboo);
+  //   CustomElements.takeRecords();
+  //   assert(removed, 'removed must be true [XBooBoo]');
+  //   done();
+  // });
+  //
+  // test('document.registerElement attributeChangedCallback in prototype', function(done) {
+  //   var XBooPrototype = Object.create(HTMLElement.prototype);
+  //   XBooPrototype.attributeChangedCallback = function(inName, inOldValue) {
+  //     if (inName == 'foo' && inOldValue=='bar'
+  //         && this.attributes.foo.value == 'zot') {
+  //       done();
+  //     }
+  //   }
+  //   var XBoo = document.registerElement('x-boo-acp', {
+  //     prototype: XBooPrototype
+  //   });
+  //   var xboo = new XBoo();
+  //   xboo.setAttribute('foo', 'bar');
+  //   xboo.setAttribute('foo', 'zot');
+  // });
+  //
+  // test('document.registerElement attachedCallbacks in prototype', function(done) {
+  //   var inserted = 0;
+  //   var XBooPrototype = Object.create(HTMLElement.prototype);
+  //   XBooPrototype.attachedCallback = function() {
+  //     inserted++;
+  //   };
+  //   var XBoo = document.registerElement('x-boo-at', {
+  //     prototype: XBooPrototype
+  //   });
+  //   var xboo = new XBoo();
+  //   assert.equal(inserted, 0, 'inserted must be 0');
+  //   work.appendChild(xboo);
+  //   CustomElements.takeRecords();
+  //   assert.equal(inserted, 1, 'inserted must be 1');
+  //   work.removeChild(xboo);
+  //   CustomElements.takeRecords();
+  //   assert(!xboo.parentNode);
+  //   work.appendChild(xboo);
+  //   CustomElements.takeRecords();
+  //   assert.equal(inserted, 2, 'inserted must be 2');
+  //   done();
+  // });
+  //
+  // test('document.registerElement detachedCallbacks in prototype', function(done) {
+  //   var ready, inserted, removed;
+  //   var XBooPrototype = Object.create(HTMLElement.prototype);
+  //   XBooPrototype.detachedCallback = function() {
+  //     removed = true;
+  //   }
+  //   var XBoo = document.registerElement('x-boo-ir2', {
+  //     prototype: XBooPrototype
+  //   });
+  //   var xboo = new XBoo();
+  //   assert(!removed, 'removed must be false [XBoo]');
+  //   work.appendChild(xboo);
+  //   CustomElements.takeRecords();
+  //   work.removeChild(xboo);
+  //   CustomElements.takeRecords();
+  //   assert(removed, 'removed must be true [XBoo]');
+  //   //
+  //   ready = inserted = removed = false;
+  //   var XBooBooPrototype = Object.create(XBooPrototype);
+  //   XBooBooPrototype.detachedCallback = function() {
+  //     XBoo.prototype.detachedCallback.call(this);
+  //   };
+  //   var XBooBoo = document.registerElement('x-booboo-ir2', {
+  //     prototype: XBooBooPrototype
+  //   });
+  //   var xbooboo = new XBooBoo();
+  //   assert(!removed, 'removed must be false [XBooBoo]');
+  //   work.appendChild(xbooboo);
+  //   CustomElements.takeRecords();
+  //   work.removeChild(xbooboo);
+  //   CustomElements.takeRecords();
+  //   assert(removed, 'removed must be true [XBooBoo]');
+  //   done();
+  // });
+  //
+  // test('document.registerElement can use Functions as definitions', function() {
+  //   // function used as Custom Element defintion
+  //   function A$A() {
+  //     this.alive = true;
+  //   }
+  //   A$A.prototype = Object.create(HTMLElement.prototype);
+  //   // bind createdCallback to function body
+  //   A$A.prototype.createdCallback = A$A;
+  //   A$A = document.registerElement('a-a', A$A);
+  //   // test via new
+  //   var a = new A$A();
+  //   assert.equal(a.alive, true);
+  //   // test via parser upgrade
+  //   work.innerHTML = '<a-a></a-a>';
+  //   CustomElements.takeRecords();
+  //   assert.equal(work.firstElementChild.alive, true);
+  // });
+  //
+  // test('node.cloneNode upgrades', function(done) {
+  //   var XBooPrototype = Object.create(HTMLElement.prototype);
+  //   XBooPrototype.createdCallback = function() {
+  //     this.__ready__ = true;
+  //   };
+  //   var XBoo = document.registerElement('x-boo-clone', {
+  //     prototype: XBooPrototype
+  //   });
+  //   var xboo = new XBoo();
+  //   work.appendChild(xboo);
+  //   CustomElements.takeRecords();
+  //   var xboo2 = xboo.cloneNode(true);
+  //   assert(xboo2.__ready__, 'clone createdCallback must be called');
+  //   done();
+  // });
+  //
+  // test('document.importNode upgrades', function() {
+  //   var XImportPrototype = Object.create(HTMLElement.prototype);
+  //   XImportPrototype.createdCallback = function() {
+  //     this.__ready__ = true;
+  //   };
+  //   document.registerElement('x-import', {
+  //     prototype: XImportPrototype
+  //   });
+  //   var frag = document.createDocumentFragment();
+  //   frag.appendChild(document.createElement('x-import'));
+  //   assert.isTrue(frag.firstChild.__ready__, 'source element upgraded');
+  //   var imported = document.importNode(frag, true);
+  //   window.imported = imported;
+  //   assert.isTrue(imported.firstChild.__ready__, 'imported element upgraded');
+  // });
+  //
+  // test('entered left apply to view', function() {
+  //   var invocations = [];
+  //   var elementProto = Object.create(HTMLElement.prototype);
+  //   elementProto.createdCallback = function() {
+  //     invocations.push('created');
+  //   }
+  //   elementProto.attachedCallback = function() {
+  //     invocations.push('entered');
+  //   }
+  //   elementProto.detachedCallback = function() {
+  //     invocations.push('left');
+  //   }
+  //   var tagName = 'x-entered-left-view';
+  //   var CustomElement = document.registerElement(tagName, { prototype: elementProto });
+  //
+  //   var docB = document.implementation.createHTMLDocument('');
+  //   docB.body.innerHTML = '<' + tagName + '></' + tagName + '>';
+  //   CustomElements.upgradeDocumentTree(docB);
+  //   CustomElements.takeRecords();
+  //   assert.deepEqual(invocations, ['created'], 'created but not entered view');
+  //
+  //   var element = docB.body.childNodes[0];
+  //   // note, cannot use instanceof due to IE
+  //   assert.equal(element.__proto__, CustomElement.prototype, 'element is correct type');
+  //
+  //   work.appendChild(element)
+  //   CustomElements.takeRecords();
+  //   assert.deepEqual(invocations, ['created', 'entered'],
+  //       'created and entered view');
+  //
+  //   docB.body.appendChild(element);
+  //   CustomElements.takeRecords();
+  //   assert.deepEqual(invocations, ['created', 'entered', 'left'],
+  //       'created, entered then left view');
+  // });
+  //
+  // test('attachedCallback ordering', function() {
+  //   var log = [];
+  //   var p = Object.create(HTMLElement.prototype);
+  //   p.attachedCallback = function() {
+  //     log.push(this.id);
+  //   };
+  //   document.registerElement('x-boo-ordering', {prototype: p});
+  //
+  //   work.innerHTML =
+  //       '<x-boo-ordering id=a>' +
+  //         '<x-boo-ordering id=b></x-boo-ordering>' +
+  //         '<x-boo-ordering id=c>' +
+  //           '<x-boo-ordering id=d></x-boo-ordering>' +
+  //           '<x-boo-ordering id=e></x-boo-ordering>' +
+  //         '</x-boo-ordering>' +
+  //       '</x-boo-ordering>';
+  //
+  //   CustomElements.takeRecords();
+  //   assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
+  // });
+  //
+  // test('attached and detached in same turn', function(done) {
+  //   var log = [];
+  //   var p = Object.create(HTMLElement.prototype);
+  //   p.attachedCallback = function() {
+  //     log.push('attached');
+  //   };
+  //   p.detachedCallback = function() {
+  //     log.push('detached');
+  //   };
+  //   document.registerElement('x-ad', {prototype: p});
+  //   var el = document.createElement('x-ad');
+  //   work.appendChild(el);
+  //   work.removeChild(el);
+  //   setTimeout(function() {
+  //     assert.deepEqual(['attached', 'detached'], log);
+  //     done();
+  //   });
+  // });
+  //
+  // test('detached and re-attached in same turn', function(done) {
+  //   var log = [];
+  //   var p = Object.create(HTMLElement.prototype);
+  //   p.attachedCallback = function() {
+  //     log.push('attached');
+  //   };
+  //   p.detachedCallback = function() {
+  //     log.push('detached');
+  //   };
+  //   document.registerElement('x-da', {prototype: p});
+  //   var el = document.createElement('x-da');
+  //   work.appendChild(el);
+  //   CustomElements.takeRecords();
+  //   log = [];
+  //   work.removeChild(el);
+  //   work.appendChild(el);
+  //   setTimeout(function() {
+  //     assert.deepEqual(['detached', 'attached'], log);
+  //     done();
+  //   });
+  // });
+  //
+  // test('detachedCallback ordering', function() {
+  //   var log = [];
+  //   var p = Object.create(HTMLElement.prototype);
+  //   p.detachedCallback = function() {
+  //    log.push(this.id);
+  //   };
+  //   document.registerElement('x-boo2-ordering', {prototype: p});
+  //
+  //   work.innerHTML =
+  //       '<x-boo2-ordering id=a>' +
+  //         '<x-boo2-ordering id=b></x-boo2-ordering>' +
+  //         '<x-boo2-ordering id=c>' +
+  //           '<x-boo2-ordering id=d></x-boo2-ordering>' +
+  //           '<x-boo2-ordering id=e></x-boo2-ordering>' +
+  //         '</x-boo2-ordering>' +
+  //       '</x-boo2-ordering>';
+  //
+  //     CustomElements.takeRecords();
+  //     work.removeChild(work.firstElementChild);
+  //     CustomElements.takeRecords();
+  //     assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
+  // });
+  //
+  // test('instanceof', function() {
+  //   var p = Object.create(HTMLElement.prototype);
+  //   var PCtor = document.registerElement('x-instance', {prototype: p});
+  //   var x = document.createElement('x-instance');
+  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-instance');
+  //   x = document.createElementNS(HTMLNS, 'x-instance');
+  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-instance');
+  //
+  //   var p2 = Object.create(PCtor.prototype);
+  //   var P2Ctor = document.registerElement('x-instance2', {prototype: p2});
+  //   var x2 = document.createElement('x-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-instance2');
+  //   x2 = document.createElementNS(HTMLNS, 'x-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-instance2');
+  // });
+  //
+  //
+  // test('instanceof typeExtension', function() {
+  //   var p = Object.create(HTMLButtonElement.prototype);
+  //   var PCtor = document.registerElement('x-button-instance', {prototype: p, extends: 'button'});
+  //   var x = document.createElement('button', 'x-button-instance');
+  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-button-instance');
+  //   assert.isTrue(CustomElements.instanceof(x, HTMLButtonElement), 'instanceof failed for x-button-instance');
+  //   x = document.createElementNS(HTMLNS, 'button', 'x-button-instance');
+  //   assert.isTrue(CustomElements.instanceof(x, PCtor), 'instanceof failed for x-button-instance');
+  //   assert.isTrue(CustomElements.instanceof(x, HTMLButtonElement), 'instanceof failed for x-button-instance');
+  //
+  //   var p2 = Object.create(PCtor.prototype);
+  //   var P2Ctor = document.registerElement('x-button-instance2', {prototype: p2, extends: 'button'});
+  //   var x2 = document.createElement('button','x-button-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-button-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-button-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, HTMLButtonElement), 'instanceof failed for x-button-instance2');
+  //   x2 = document.createElementNS(HTMLNS, 'button','x-button-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, P2Ctor), 'instanceof failed for x-button-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, PCtor), 'instanceof failed for x-button-instance2');
+  //   assert.isTrue(CustomElements.instanceof(x2, HTMLButtonElement), 'instanceof failed for x-button-instance2');
+  // });
+  //
+  // test('extends and prototype mismatch', function() {
+  //   var p = Object.create(HTMLElement.prototype);
+  //   var PCtor = document.registerElement('not-button', {
+  //     extends: 'button',
+  //     prototype: p
+  //   });
+  //
+  //   var e = document.createElement('button', 'not-button');
+  //
+  //   // NOTE: firefox has a hack for instanceof that uses element tagname mapping
+  //   // Work around by checking prototype manually
+  //   //
+  //   var ff = document.createElement('button'); ff.__proto__ = null;
+  //   if (ff instanceof HTMLButtonElement) {
+  //     // Base proto will be one below custom proto
+  //     var proto = e.__proto__.__proto__;
+  //     assert.isFalse(proto === HTMLButtonElement.prototype);
+  //     assert.isTrue(proto === HTMLElement.prototype);
+  //   } else {
+  //     assert.isFalse(CustomElements.instanceof(e, HTMLButtonElement));
+  //     assert.isTrue(CustomElements.instanceof(e, HTMLElement));
+  //   }
+  // });
+
+});

--- a/tests/CustomElements/v1/js/typescript.js
+++ b/tests/CustomElements/v1/js/typescript.js
@@ -12,7 +12,7 @@ suite('typescript', function() {
 
   // Fails because the XTypescript constructor does not return the result of
   // the super call. See: https://github.com/Microsoft/TypeScript/issues/7574
-  test.skip('document.defineElement create typescript generated ES5 via new', function() {
+  test.skip('customElements.define create typescript generated ES5 via new', function() {
     var __extends = (this && this.__extends) || function (d, b) {
         for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
         function __() { this.constructor = d; }
@@ -28,7 +28,7 @@ suite('typescript', function() {
     }(HTMLElement));
 
     // register x-foo
-    document.defineElement('x-typescript', XTypescript);
+    customElements.define('x-typescript', XTypescript);
     // create an instance via new
     var e = new XTypescript();
     console.log(e);
@@ -38,7 +38,7 @@ suite('typescript', function() {
     assert.instanceOf(e, XTypescript);
   });
 
-  test('document.defineElement create typescript generated ES5 via createElement', function() {
+  test('customElements.define create typescript generated ES5 via createElement', function() {
     var __extends = (this && this.__extends) || function (d, b) {
         for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
         function __() { this.constructor = d; }
@@ -54,7 +54,7 @@ suite('typescript', function() {
     }(HTMLElement));
 
     // register x-foo
-    document.defineElement('x-typescript2', XTypescript2);
+    customElements.define('x-typescript2', XTypescript2);
     // create an instance via new
     var e = document.createElement('x-typescript2');
     console.log(e);

--- a/tests/CustomElements/v1/js/typescript.js
+++ b/tests/CustomElements/v1/js/typescript.js
@@ -21,7 +21,6 @@ suite('typescript', function() {
     var XTypescript = (function (_super) {
         __extends(XTypescript, _super);
         function XTypescript() {
-            customElements.currentTag = 'x-typescript';
             _super.call(this);
         }
         return XTypescript;
@@ -31,7 +30,6 @@ suite('typescript', function() {
     customElements.define('x-typescript', XTypescript);
     // create an instance via new
     var e = new XTypescript();
-    console.log(e);
     // test localName
     assert.equal(e.localName, 'x-typescript');
     // test instanceof
@@ -47,7 +45,6 @@ suite('typescript', function() {
     var XTypescript2 = (function (_super) {
         __extends(XTypescript2, _super);
         function XTypescript2() {
-            customElements.currentTag = 'x-typescript2';
             _super.call(this);
         }
         return XTypescript2;
@@ -57,7 +54,6 @@ suite('typescript', function() {
     customElements.define('x-typescript2', XTypescript2);
     // create an instance via new
     var e = document.createElement('x-typescript2');
-    console.log(e);
     // test localName
     assert.equal(e.localName, 'x-typescript2');
     // test instanceof

--- a/tests/CustomElements/v1/js/typescript.js
+++ b/tests/CustomElements/v1/js/typescript.js
@@ -21,7 +21,7 @@ suite('typescript', function() {
     var XTypescript = (function (_super) {
         __extends(XTypescript, _super);
         function XTypescript() {
-            CustomElements.setCurrentTag('x-typescript');
+            customElements.setCurrentTag('x-typescript');
             _super.call(this);
         }
         return XTypescript;
@@ -47,7 +47,7 @@ suite('typescript', function() {
     var XTypescript2 = (function (_super) {
         __extends(XTypescript2, _super);
         function XTypescript2() {
-            CustomElements.setCurrentTag('x-typescript2');
+            customElements.setCurrentTag('x-typescript2');
             _super.call(this);
         }
         return XTypescript2;

--- a/tests/CustomElements/v1/js/typescript.js
+++ b/tests/CustomElements/v1/js/typescript.js
@@ -21,7 +21,7 @@ suite('typescript', function() {
     var XTypescript = (function (_super) {
         __extends(XTypescript, _super);
         function XTypescript() {
-            customElements.setCurrentTag('x-typescript');
+            customElements.currentTag = 'x-typescript';
             _super.call(this);
         }
         return XTypescript;
@@ -47,7 +47,7 @@ suite('typescript', function() {
     var XTypescript2 = (function (_super) {
         __extends(XTypescript2, _super);
         function XTypescript2() {
-            customElements.setCurrentTag('x-typescript2');
+            customElements.currentTag = 'x-typescript2';
             _super.call(this);
         }
         return XTypescript2;

--- a/tests/CustomElements/v1/js/typescript.js
+++ b/tests/CustomElements/v1/js/typescript.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('typescript', function() {
+
+  // Fails because the XTypescript constructor does not return the result of
+  // the super call. See: https://github.com/Microsoft/TypeScript/issues/7574
+  test.skip('document.defineElement create typescript generated ES5 via new', function() {
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var XTypescript = (function (_super) {
+        __extends(XTypescript, _super);
+        function XTypescript() {
+            CustomElements.setCurrentTag('x-typescript');
+            _super.call(this);
+        }
+        return XTypescript;
+    }(HTMLElement));
+
+    // register x-foo
+    document.defineElement('x-typescript', XTypescript);
+    // create an instance via new
+    var e = new XTypescript();
+    console.log(e);
+    // test localName
+    assert.equal(e.localName, 'x-typescript');
+    // test instanceof
+    assert.instanceOf(e, XTypescript);
+  });
+
+  test('document.defineElement create typescript generated ES5 via createElement', function() {
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var XTypescript2 = (function (_super) {
+        __extends(XTypescript2, _super);
+        function XTypescript2() {
+            CustomElements.setCurrentTag('x-typescript2');
+            _super.call(this);
+        }
+        return XTypescript2;
+    }(HTMLElement));
+
+    // register x-foo
+    document.defineElement('x-typescript2', XTypescript2);
+    // create an instance via new
+    var e = document.createElement('x-typescript2');
+    console.log(e);
+    // test localName
+    assert.equal(e.localName, 'x-typescript2');
+    // test instanceof
+    assert.instanceOf(e, XTypescript2);
+
+  });
+
+});

--- a/tests/CustomElements/v1/js/upgrade.js
+++ b/tests/CustomElements/v1/js/upgrade.js
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('upgrade', function() {
+  var work;
+  var assert = chai.assert;
+
+  setup(function() {
+    work = document.createElement('div');
+    document.body.appendChild(work);
+  });
+
+  teardown(function() {
+    document.body.removeChild(work);
+  });
+
+  function registerTestComponent(inName, inValue) {
+    var C = class extends HTMLElement {
+      constructor() {
+        customElements.setCurrentTag('inName');
+        super();
+      }
+    };
+    C.prototype.value = inValue || 'value';
+    customElements.define(inName, C);
+  }
+
+  function testElements(node, selector, value) {
+    Array.prototype.forEach.call(node.querySelectorAll(selector), function(n) {
+      assert.equal(n.value, value);
+    });
+  }
+
+  test('custom element automatically upgrades', function(done) {
+    work.innerHTML = '<x-auto></x-auto>';
+    var x = work.firstChild;
+    // must flush after mutations to avoid false passes
+    customElements.flush();
+    assert.isUndefined(x.value);
+    registerTestComponent('x-auto', 'auto');
+    assert.equal(x.value, 'auto');
+    done();
+  });
+
+  test('custom element automatically upgrades in subtree', function(done) {
+    work.innerHTML = '<div></div>';
+    var target = work.firstChild;
+    target.innerHTML = '<x-auto-sub></x-auto-sub>';
+    var x = target.firstChild;
+    // must flush after mutations to avoid false passes
+    customElements.flush();
+    assert.isUndefined(x.value);
+    registerTestComponent('x-auto-sub', 'auto-sub');
+    assert.equal(x.value, 'auto-sub');
+    done();
+  });
+
+  test('custom elements automatically upgrade', function(done) {
+    registerTestComponent('x-auto1', 'auto1');
+    registerTestComponent('x-auto2', 'auto2');
+    work.innerHTML = '<div><div><x-auto1></x-auto1><x-auto1></x-auto1>' +
+      '</div></div><div><x-auto2><x-auto1></x-auto1></x-auto2>' +
+      '<x-auto2><x-auto1></x-auto1></x-auto2></div>';
+    customElements.flush();
+    testElements(work, 'x-auto1', 'auto1');
+    testElements(work, 'x-auto2', 'auto2');
+    done();
+  });
+
+  test('custom elements automatically upgrade in subtree', function(done) {
+    registerTestComponent('x-auto-sub1', 'auto-sub1');
+    registerTestComponent('x-auto-sub2', 'auto-sub2');
+    work.innerHTML = '<div></div>';
+    var target = work.firstChild;
+    target.innerHTML = '<div><div><x-auto-sub1></x-auto-sub1><x-auto-sub1></x-auto-sub1>' +
+      '</div></div><div><x-auto-sub2><x-auto-sub1></x-auto-sub1></x-auto-sub2>' +
+      '<x-auto-sub2><x-auto-sub1></x-auto-sub1></x-auto-sub2></div>';
+    customElements.flush();
+    testElements(target, 'x-auto-sub1', 'auto-sub1');
+    testElements(target, 'x-auto-sub2', 'auto-sub2');
+    done();
+  });
+
+  test('CustomElements.upgrade upgrades custom element syntax', function() {
+    registerTestComponent('x-foo31', 'foo');
+    work.innerHTML = '<x-foo31>Foo</x-foo31>';
+    var xfoo = work.firstChild;
+    customElements.flush();
+    assert.equal(xfoo.value, 'foo');
+  });
+
+  test('mutation observer upgrades custom element syntax', function(done) {
+    registerTestComponent('x-foo32', 'foo');
+    work.innerHTML = '<x-foo32>Foo</x-foo32>';
+    customElements.flush();
+    var xfoo = work.firstChild;
+    assert.equal(xfoo.value, 'foo');
+    done();
+  });
+
+  test('document.register upgrades custom element syntax', function() {
+    work.innerHTML = '<x-foo33>Foo</x-foo33>';
+    registerTestComponent('x-foo33', 'foo');
+    var xfoo = work.firstChild;
+    assert.equal(xfoo.value, 'foo');
+  });
+
+  test('CustomElements.upgrade upgrades custom element syntax', function() {
+    registerTestComponent('x-zot', 'zot');
+    registerTestComponent('x-zim', 'zim');
+    work.innerHTML = '<x-zot><x-zim></x-zim></x-zot>';
+    var xzot = work.firstChild, xzim = xzot.firstChild;
+    customElements.flush();
+    assert.equal(xzot.value, 'zot');
+    assert.equal(xzim.value, 'zim');
+  });
+});

--- a/tests/CustomElements/v1/js/upgrade.js
+++ b/tests/CustomElements/v1/js/upgrade.js
@@ -22,12 +22,7 @@ suite('upgrade', function() {
   });
 
   function registerTestComponent(inName, inValue) {
-    var C = class extends HTMLElement {
-      constructor() {
-        customElements.currentTag = 'inName';
-        super();
-      }
-    };
+    var C = class extends HTMLElement {};
     C.prototype.value = inValue || 'value';
     customElements.define(inName, C);
   }

--- a/tests/CustomElements/v1/js/upgrade.js
+++ b/tests/CustomElements/v1/js/upgrade.js
@@ -24,7 +24,7 @@ suite('upgrade', function() {
   function registerTestComponent(inName, inValue) {
     var C = class extends HTMLElement {
       constructor() {
-        customElements.setCurrentTag('inName');
+        customElements.currentTag = 'inName';
         super();
       }
     };

--- a/tests/CustomElements/v1/runner.html
+++ b/tests/CustomElements/v1/runner.html
@@ -20,6 +20,7 @@
     'js/customElements.js',
     'js/typescript.js',
     'js/babel.js',
+    'js/closure.js',
     // 'html/attributes.html',
     // 'html/customevent-detail.html',
     // 'html/upgrade-order.html',

--- a/tests/CustomElements/v1/runner.html
+++ b/tests/CustomElements/v1/runner.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<title>CustomElements Tests</title>
+<meta charset="utf-8">
+
+<script src="../../../src/CustomElements/v1/CustomElements.js"></script>
+<script src="../../../../web-component-tester/browser.js"></script>
+
+<script>
+  WCT.loadSuites([
+    'js/customElements.js',
+    // 'html/attributes.html',
+    // 'html/customevent-detail.html',
+    // 'html/upgrade-order.html',
+    // 'html/upgrade-dcl.html',
+    // 'html/imports.html',
+    // 'html/shadowdom.html',
+    // 'js/upgrade.js',
+    // 'js/observe.js',
+    // 'js/documentRegister.js',
+    // 'html/throttled-attached.html'
+  ]);
+</script>

--- a/tests/CustomElements/v1/runner.html
+++ b/tests/CustomElements/v1/runner.html
@@ -12,6 +12,7 @@
 <meta charset="utf-8">
 
 <script src="../../../dist/CustomElementsV1.min.js"></script>
+<!-- <script src="../../../src/CustomElements/v1/CustomElements.js"></script> -->
 <script src="../../../../web-component-tester/browser.js"></script>
 
 <script>

--- a/tests/CustomElements/v1/runner.html
+++ b/tests/CustomElements/v1/runner.html
@@ -11,7 +11,7 @@
 <title>CustomElements Tests</title>
 <meta charset="utf-8">
 
-<script src="../../../src/CustomElements/v1/CustomElements.js"></script>
+<script src="../../../dist/CustomElementsV1.min.js"></script>
 <script src="../../../../web-component-tester/browser.js"></script>
 
 <script>

--- a/tests/CustomElements/v1/runner.html
+++ b/tests/CustomElements/v1/runner.html
@@ -17,6 +17,8 @@
 <script>
   WCT.loadSuites([
     'js/customElements.js',
+    'js/typescript.js',
+    'js/babel.js',
     // 'html/attributes.html',
     // 'html/customevent-detail.html',
     // 'html/upgrade-order.html',

--- a/tests/CustomElements/v1/runner.html
+++ b/tests/CustomElements/v1/runner.html
@@ -25,7 +25,7 @@
     // 'html/upgrade-dcl.html',
     // 'html/imports.html',
     // 'html/shadowdom.html',
-    // 'js/upgrade.js',
+    'js/upgrade.js',
     // 'js/observe.js',
     // 'js/documentRegister.js',
     // 'html/throttled-attached.html'


### PR DESCRIPTION
This works towards supporting the repo itself as an NPM package, so that it's possible to put something like

``` json
"webcomponents.js": "webcomponents/webcomponentsjs#v1"
```

inside of a dependent's package.json `dependencies`.

This is needed so we can import the `v1` branch from GitHub into a project by doing

``` bash
npm install
```

``` js
import `webcomponents.js`
```

instead of

``` bash
npm install
cd node_modules/webcomponents.js
gulp build
```

``` js
import `webcomponents.js/dist/webcomponents.js`
```

I tested this by renaming the package to random `test-aksdfhasdfkjqhwecuasdfkashjf` and publishing: https://www.npmjs.com/package/test-aksdfhasdfkjqhwecuasdfkashjf

This means that running `npm publish` will automatically build before publishing, and will only publish the `dist` folder, and `require('webcomponents.js')` will load the dist file.

This is also useful for `npm link` workflows, as that will also run `npm install && npm prepublish` behind the scenes in order to make local development easier.
