### PR TITLE
Check or performance.now existence

### DIFF
--- a/src/WebComponents/dom.js
+++ b/src/WebComponents/dom.js
@@ -14,7 +14,8 @@
 
   // polyfill performance.now
 
-  if (!window.performance) {
+  // Note: old Safari has performance, but not now().
+  if (!(window.performance && window.performance.now)) {
     var start = Date.now();
     // only at millisecond precision
     window.performance = {now: function(){ return Date.now() - start; }};


### PR DESCRIPTION
R: @garlicnation @azakus @justinfagnani 

Fixes #539.

Old versions of safari/ios have performance but not performance.now