### PR TITLE
Add support for old Opera/Presto engine.

### DIFF
--- a/src/HTMLImports/Loader.js
+++ b/src/HTMLImports/Loader.js
@@ -49,7 +49,16 @@ Loader.prototype = {
   },
 
   require: function(elt) {
-    var url = elt.src || elt.href;
+    var url;
+    if (elt.ownerDocument.baseURI) {
+      url = elt.src || elt.href;
+    } else {
+      // Old Opera/Presto does not reflect correct baseURI in XHR'ed doc; fix up
+      var href = elt.getAttribute('src') || elt.getAttribute('href');
+      var lastSlash = elt.ownerDocument._URL.lastIndexOf('/');
+      var base = elt.ownerDocument._URL.substring(0, lastSlash + 1);
+      url = new URL(href, base).href;
+    }
     // ensure we have a standard url that can be used
     // reliably for deduping.
     // TODO(sjmiles): ad-hoc

--- a/src/HTMLImports/base.js
+++ b/src/HTMLImports/base.js
@@ -71,6 +71,7 @@ Object.defineProperty(rootDocument, '_currentScript', currentScriptDescriptor);
  */
 
 var isIE = /Trident/.test(navigator.userAgent);
+var isOldOpera = /Presto/.test(navigator.userAgent);
 
 // call a callback when all HTMLImports in the document at call time
 // (or at least document ready) have loaded.
@@ -237,5 +238,6 @@ scope.useNative = useNative;
 scope.rootDocument = rootDocument;
 scope.whenReady = whenReady;
 scope.isIE = isIE;
+scope.isOldOpera = isOldOpera;
 
 })(window.HTMLImports);

--- a/src/HTMLImports/dynamic.js
+++ b/src/HTMLImports/dynamic.js
@@ -60,6 +60,7 @@ var matches = HTMLElement.prototype.matches ||
     HTMLElement.prototype.matchesSelector ||
     HTMLElement.prototype.webkitMatchesSelector ||
     HTMLElement.prototype.mozMatchesSelector ||
-    HTMLElement.prototype.msMatchesSelector;
+    HTMLElement.prototype.msMatchesSelector ||
+    HTMLElement.prototype.oMatchesSelector;
 
 });

--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -14,6 +14,7 @@ var path = scope.path;
 var rootDocument = scope.rootDocument;
 var flags = scope.flags;
 var isIE = scope.isIE;
+var isOldOpera = scope.isOldOpera;
 var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
 var IMPORT_SELECTOR = 'link[rel=' + IMPORT_LINK_TYPE + ']';
 
@@ -191,7 +192,7 @@ var importParser = {
 
     // NOTE: IE does not fire "load" event for styles that have already loaded
     // This is in violation of the spec, so we try our hardest to work around it
-    if (isIE && elt.localName === 'style') {
+    if ((isIE || isOldOpera) && elt.localName === 'style') {
       var fakeLoad = false;
       // If there's not @import in the textContent, assume it has loaded
       if (elt.textContent.indexOf('@import') == -1) {

--- a/src/ShadowDOM/wrappers/Element.js
+++ b/src/ShadowDOM/wrappers/Element.js
@@ -32,6 +32,7 @@
     'mozMatchesSelector',
     'msMatchesSelector',
     'webkitMatchesSelector',
+    'oMatchesSelector'
   ].filter(function(name) {
     return OriginalElement.prototype[name];
   });

--- a/tests/ShadowDOM/js/HTMLHtmlElement.js
+++ b/tests/ShadowDOM/js/HTMLHtmlElement.js
@@ -58,7 +58,8 @@ suite('HTMLHtmlElement', function() {
     var matches = html.matchesSelector ||
         html.mozMatchesSelector ||
         html.webkitMatchesSelector ||
-        html.msMatchesSelector;
+        html.msMatchesSelector ||
+        html.oMatchesSelector;
 
     assert.isTrue(matches.call(document.body, 'body'));
     assert.isTrue(matches.call(wrap(document.body), 'body'));


### PR DESCRIPTION
Adds minimal support for old Opera Presto engine:
- need to use `oMatchesSelector`
- need to use "fakeLoad" logic for `<style>` elements added for IE
- need to fix up URL's in linked imports, as XHR'ed docs do not respect the baseURI
