### PR TITLE
Remove not required else block

### DIFF
--- a/src/WebComponents/build/boot-lite.js
+++ b/src/WebComponents/build/boot-lite.js
@@ -37,14 +37,12 @@
       }
     }
     // log flags
+    flags.log = {};
     if (flags.log && flags.log.split) {
       var parts = flags.log.split(',');
-      flags.log = {};
       parts.forEach(function(f) {
         flags.log[f] = true;
       });
-    } else {
-      flags.log = {};
     }
   }
 


### PR DESCRIPTION
Simplify a block by removing not required else, since the line is always executed on both blocks (if /else) there is no need to define such blocks.