### PR TITLE
Build Template as a separate polyfill

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,9 +128,10 @@ defineBuildTask('CustomElements');
 defineBuildTask('HTMLImports');
 defineBuildTask('ShadowDOM');
 defineBuildTask('MutationObserver');
+defineBuildTask('Template');
 
 gulp.task('build', ['webcomponents', 'webcomponents-lite', 'CustomElements', 
-  'HTMLImports', 'ShadowDOM', 'copy-bower', 'MutationObserver']);
+  'HTMLImports', 'ShadowDOM', 'copy-bower', 'MutationObserver', 'Template']);
 
 gulp.task('release', function(cb) {
   isRelease = true;

--- a/src/Template/Template.js
+++ b/src/Template/Template.js
@@ -144,6 +144,17 @@
       return el;
     };
 
+    // Patch document.createElementNS to ensure newly created templates have content
+    var createElementNS = document.createElementNS;
+    document.createElementNS = function() {
+      'use strict';
+      var el = createElementNS.apply(document, arguments);
+      if (el.namespaceURI === 'http://www.w3.org/1999/xhtml' && el.localName === 'template') {
+        TemplateImpl.decorate(el);
+      }
+      return el;
+    };
+
     var escapeDataRegExp = /[&\u00A0<>]/g;
 
     function escapeReplace(c) {

--- a/src/Template/build.json
+++ b/src/Template/build.json
@@ -1,0 +1,3 @@
+[
+  "Template.js"
+]


### PR DESCRIPTION
webcomponents.js's implementation of the `<template>` polyfill can be used outside of the Shadow DOM use-cases.  This PR adds `dist/Template.js` to the list of built files.

The second commit adds an override for `document.createElementNS` for `<template>`.  Happy to file a new PR for it if you prefer.
