### PR TITLE
Simulate native `constructor` descriptor

### DIFF
--- a/src/CustomElements/v1/CustomElements.js
+++ b/src/CustomElements/v1/CustomElements.js
@@ -489,8 +489,10 @@ var CustomElementDefinition;
       }
       throw new Error('unknown constructor. Did you call customElements.define()?');
     }
-    patched.prototype = Object.create(orig.prototype);
-    Object.defineProperty(patched.prototype, 'constructor', {value: patched});
+    patched.prototype = Object.create(
+      orig.prototype,
+      {constructor: {configurable: true, value:patched, writable: true}}
+    );
   }
 
   patchConstructor('HTMLElement');


### PR DESCRIPTION
This change uses a patched `constructor` descriptor that is similar to a native one and fixes https://github.com/skatejs/web-components/issues/2