### PR TITLE
Partial fix for #112

### DIFF
--- a/src/ShadowDOM/querySelector.js
+++ b/src/ShadowDOM/querySelector.js
@@ -136,6 +136,7 @@
     var target = unsafeUnwrap(this);
     var list;
     var root = getTreeScope(this).root;
+    root = (!deep && root.shadowRoot) || root;
     if (root instanceof scope.wrappers.ShadowRoot) {
       // We are in the shadow tree and the logical tree is
       // going to be disconnected so we do a manual tree traversal
@@ -162,6 +163,7 @@
       var target = unsafeUnwrap(this);
       var wrappedItem;
       var root = getTreeScope(this).root;
+      root = (!deep && root.shadowRoot) || root;
       if (root instanceof scope.wrappers.ShadowRoot) {
         // We are in the shadow tree and the logical tree is
         // going to be disconnected so we do a manual tree traversal
@@ -220,6 +222,7 @@
     var target = unsafeUnwrap(this);
     var list;
     var root = getTreeScope(this).root;
+    root = root.shadowRoot || root;
     if (root instanceof scope.wrappers.ShadowRoot) {
       // We are in the shadow tree and the logical tree is
       // going to be disconnected so we do a manual tree traversal
@@ -243,6 +246,7 @@
     var target = unsafeUnwrap(this);
     var list;
     var root = getTreeScope(this).root;
+    root = root.shadowRoot || root;
     if (root instanceof scope.wrappers.ShadowRoot) {
       // We are in the shadow tree and the logical tree is
       // going to be disconnected so we do a manual tree traversal

--- a/tests/ShadowDOM/js/Element.js
+++ b/tests/ShadowDOM/js/Element.js
@@ -19,8 +19,6 @@ suite('Element', function() {
     div = null;
   });
 
-  function skipTest () {}
-
   test('querySelector', function() {
     var div = document.createElement('div');
     div.innerHTML = '<a><b></b></a>';
@@ -57,7 +55,7 @@ suite('Element', function() {
     assert.equal(as.item(1), a1);
   });
 
-  skipTest('querySelectorAll', function() {
+  test('querySelectorAll', function() {
     var div = document.createElement('div');
     div.innerHTML = '<a>0</a><a>1</a>';
     var a0 = div.firstChild;
@@ -91,7 +89,6 @@ suite('Element', function() {
     var div = document.createElement('div');
     div.innerHTML = '<aa></aa><aa></aa>';
     var aa1 = div.firstChild;
-    var aa2 = div.lastChild;
 
     var sr = div.createShadowRoot();
     sr.innerHTML = '<bb></bb><content></content>';
@@ -169,7 +166,7 @@ suite('Element', function() {
     assert.isTrue(p.matches('.host-class /deep/ p.child-class'));
   });
 
-  skipTest('getElementsByTagName', function() {
+  test('getElementsByTagName', function() {
     var div = document.createElement('div');
     div.innerHTML = '<a>0</a><a>1</a>';
     var a0 = div.firstChild;
@@ -263,7 +260,7 @@ suite('Element', function() {
     assert.equal(z.length, 0);
   });
 
-  skipTest('getElementsByClassName', function() {
+  test('getElementsByClassName', function() {
     var div = document.createElement('div');
     div.innerHTML = '<span class=a>0</span><span class=a>1</span>';
     var a0 = div.firstChild;


### PR DESCRIPTION
This is a partial fix for #112. It allows to select elements from element even when there is no `<content>` in its Shadow Root.
I know this a hack, not a complete fix, but:
- this is much better than nothing
- complete implementation would be quite complex (from what I understood)
- complete implementation is not likely to ever happen because of v1

Having that said I think it is better to have at least this partial fix.
