### PR TITLE
feature(htmlimport): support cors  `withCredentials` using link rel="import-cors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ ShadowCSS `:host()` rules can only have (at most) 1-level of nested parentheses 
 ### HTML imports: document.currentScript doesn't work as expected <a id="currentscript"></a>
 In native HTML Imports, document.currentScript.ownerDocument references the import document itself. In the polyfill use document._currentScript.ownerDocument (note the underscore).
 
+#### withCredentials
+
+Note that the current implementation of `HTMLImports` not support the `withCredentials` CORS option. It has been added here in HTMLImportsCors. Use with:
+
+```
+<link rel="import-cors" href="https://mycorsprotectedresource.org/somefile.html"></link>
+<script type="text/javascript">
+  window.HTMLImportsCors = { flags: { withCredentials: true } }
+</script>
+<script src="webcomponents.js"></script>
+```
+
 ### execCommand and contenteditable isn't supported under Shadow DOM <a id="execcommand"></a>
 See [#212](https://github.com/webcomponents/webcomponentsjs/issues/212)
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,11 +126,12 @@ defineBuildTask('webcomponents', './src/WebComponents/build.json');
 defineBuildTask('webcomponents-lite', './src/WebComponents/build-lite.json');
 defineBuildTask('CustomElements');
 defineBuildTask('HTMLImports');
+defineBuildTask('HTMLImportsCors');
 defineBuildTask('ShadowDOM');
 defineBuildTask('MutationObserver');
 
 gulp.task('build', ['webcomponents', 'webcomponents-lite', 'CustomElements', 
-  'HTMLImports', 'ShadowDOM', 'copy-bower', 'MutationObserver']);
+  'HTMLImports', 'HTMLImportsCors', 'ShadowDOM', 'copy-bower', 'MutationObserver']);
 
 gulp.task('release', function(cb) {
   isRelease = true;

--- a/src/HTMLImportsCors/HTMLImports.js
+++ b/src/HTMLImportsCors/HTMLImports.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+(function() {
+
+// Establish polyfill scope. We do this here to store flags. Flags are not
+// supported in the build.
+window.HTMLImportsCors = window.HTMLImportsCors || {flags:{}};
+
+// Flags. Convert url arguments to flags
+var flags = {};
+if (!flags.noOpts) {
+  location.search.slice(1).split('&').forEach(function(option) {
+    var parts = option.split('=');
+    var match;
+    if (parts[0] && (match = parts[0].match(/wc-(.+)/))) {
+      flags[match[1]] = parts[1] || true;
+    }
+  });
+}
+
+// Load.
+var file = 'HTMLImportsCors.js';
+
+var modules = [
+  '../WeakMap/WeakMap.js',
+  '../MutationObserver/MutationObserver.js',
+  '../WebComponents/dom.js',
+  'base.js',
+  'module.js',
+  'path.js',
+  'xhr.js',
+  'Loader.js',
+  'Observer.js',
+  'parser.js',
+  'importer.js',
+  'dynamic.js',
+  'boot.js'
+];
+
+var src =
+  document.querySelector('script[src*="' + file + '"]').getAttribute('src');
+var basePath = src.slice(0, src.indexOf(file));
+
+modules.forEach(function(f) {
+  document.write('<script src="' + basePath + f + '"></script>');
+});
+
+// exports
+window.HTMLImportsCors.flags = flags;
+
+})();

--- a/src/HTMLImportsCors/Loader.js
+++ b/src/HTMLImportsCors/Loader.js
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+// imports
+var xhr = scope.xhr;
+var flags = scope.flags;
+
+// This loader supports a dynamic list of urls
+// and an oncomplete callback that is called when the loader is done.
+// NOTE: The polyfill currently does *not* need this dynamism or the
+// onComplete concept. Because of this, the loader could be simplified
+// quite a bit.
+var Loader = function(onLoad, onComplete) {
+  this.cache = {};
+  this.onload = onLoad;
+  this.oncomplete = onComplete;
+  this.inflight = 0;
+  this.pending = {};
+};
+
+Loader.prototype = {
+
+  addNodes: function(nodes) {
+    // number of transactions to complete
+    this.inflight += nodes.length;
+    // commence transactions
+    for (var i=0, l=nodes.length, n; (i<l) && (n=nodes[i]); i++) {
+      this.require(n);
+    }
+    // anything to do?
+    this.checkDone();
+  },
+
+  addNode: function(node) {
+    // number of transactions to complete
+    this.inflight++;
+    // commence transactions
+    this.require(node);
+    // anything to do?
+    this.checkDone();
+  },
+
+  require: function(elt) {
+    var url = elt.src || elt.href;
+    // ensure we have a standard url that can be used
+    // reliably for deduping.
+    // TODO(sjmiles): ad-hoc
+    elt.__nodeUrl = url;
+    // deduplication
+    if (!this.dedupe(url, elt)) {
+      // fetch this resource
+      this.fetch(url, elt);
+    }
+  },
+
+  dedupe: function(url, elt) {
+    if (this.pending[url]) {
+      // add to list of nodes waiting for inUrl
+      this.pending[url].push(elt);
+      // don't need fetch
+      return true;
+    }
+    var resource;
+    if (this.cache[url]) {
+      this.onload(url, elt, this.cache[url]);
+      // finished this transaction
+      this.tail();
+      // don't need fetch
+      return true;
+    }
+    // first node waiting for inUrl
+    this.pending[url] = [elt];
+    // need fetch (not a dupe)
+    return false;
+  },
+
+  fetch: function(url, elt) {
+    flags.load && console.log('fetch', url, elt);
+    if (!url) {
+      setTimeout(function() {
+        this.receive(url, elt, {error: 'href must be specified'}, null);
+      }.bind(this), 0);
+    } else if (url.match(/^data:/)) {
+      // Handle Data URI Scheme
+      var pieces = url.split(',');
+      var header = pieces[0];
+      var body = pieces[1];
+      if(header.indexOf(';base64') > -1) {
+        body = atob(body);
+      } else {
+        body = decodeURIComponent(body);
+      }
+      setTimeout(function() {
+          this.receive(url, elt, null, body);
+      }.bind(this), 0);
+    } else {
+      var receiveXhr = function(err, resource, redirectedUrl) {
+        this.receive(url, elt, err, resource, redirectedUrl);
+      }.bind(this);
+      xhr.load(url, receiveXhr);
+    }
+  },
+
+  receive: function(url, elt, err, resource, redirectedUrl) {
+    this.cache[url] = resource;
+    var $p = this.pending[url];
+    for (var i=0, l=$p.length, p; (i<l) && (p=$p[i]); i++) {
+      // If url was redirected, use the redirected location so paths are
+      // calculated relative to that.
+      this.onload(url, p, resource, err, redirectedUrl);
+      this.tail();
+    }
+    this.pending[url] = null;
+  },
+
+  tail: function() {
+    --this.inflight;
+    this.checkDone();
+  },
+
+  checkDone: function() {
+    if (!this.inflight) {
+      this.oncomplete();
+    }
+  }
+
+};
+
+// exports
+scope.Loader = Loader;
+
+});

--- a/src/HTMLImportsCors/Observer.js
+++ b/src/HTMLImportsCors/Observer.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+/*
+  Use a mutation observer to call a callback for all added nodes.
+*/
+var Observer = function(addCallback) {
+  this.addCallback = addCallback;
+  this.mo = new MutationObserver(this.handler.bind(this));
+};
+
+Observer.prototype = {
+
+  // we track mutations for addedNodes, looking for imports
+  handler: function(mutations) {
+    for (var i=0, l=mutations.length, m; (i<l) && (m=mutations[i]); i++) {
+      if (m.type === 'childList' && m.addedNodes.length) {
+        this.addedNodes(m.addedNodes);
+      }
+    }
+  },
+
+  addedNodes: function(nodes) {
+    if (this.addCallback) {
+      this.addCallback(nodes);
+    }
+    for (var i=0, l=nodes.length, n, loading; (i<l) && (n=nodes[i]); i++) {
+      if (n.children && n.children.length) {
+        this.addedNodes(n.children);
+      }
+    }
+  },
+
+  observe: function(root) {
+    this.mo.observe(root, {childList: true, subtree: true});
+  }
+
+};
+
+// exports
+scope.Observer = Observer;
+
+});

--- a/src/HTMLImportsCors/base.js
+++ b/src/HTMLImportsCors/base.js
@@ -1,0 +1,241 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/*
+ * PLEASE NOTE: This file is duplicated within Polymer. Please keep it in sync!
+ * https://github.com/Polymer/polymer/blob/master/src/system/HTMLImportsCors/base.js
+ */
+
+/*
+	Create polyfill scope and feature detect native support.
+*/
+window.HTMLImportsCors = window.HTMLImportsCors || {flags:{}};
+
+(function(scope) {
+
+/**
+	Basic setup and simple module executer. We collect modules and then execute
+  the code later, only if it's necessary for polyfilling.
+*/
+var IMPORT_LINK_TYPE = 'import-cors';
+var useNative = Boolean(IMPORT_LINK_TYPE in document.createElement('link'));
+
+/**
+  Support `currentScript` on all browsers as `document._currentScript.`
+
+  NOTE: We cannot polyfill `document.currentScript` because it's not possible
+  both to override and maintain the ability to capture the native value.
+  Therefore we choose to expose `_currentScript` both when native imports
+  and the polyfill are in use.
+*/
+// NOTE: ShadowDOMPolyfill intrusion.
+var hasShadowDOMPolyfill = Boolean(window.ShadowDOMPolyfill);
+var wrap = function(node) {
+  return hasShadowDOMPolyfill ? window.ShadowDOMPolyfill.wrapIfNeeded(node) : node;
+};
+var rootDocument = wrap(document);
+
+var currentScriptDescriptor = {
+  get: function() {
+    var script = window.HTMLImportsCors.currentScript || document.currentScript ||
+        // NOTE: only works when called in synchronously executing code.
+        // readyState should check if `loading` but IE10 is
+        // interactive when scripts run so we cheat.
+        (document.readyState !== 'complete' ?
+        document.scripts[document.scripts.length - 1] : null);
+    return wrap(script);
+  },
+  configurable: true
+};
+
+Object.defineProperty(document, '_currentScript', currentScriptDescriptor);
+Object.defineProperty(rootDocument, '_currentScript', currentScriptDescriptor);
+
+/**
+  Add support for the `HTMLImportsCorsLoaded` event and the `HTMLImportsCors.whenReady`
+  method. This api is necessary because unlike the native implementation,
+  script elements do not force imports to resolve. Instead, users should wrap
+  code in either an `HTMLImportsCorsLoaded` handler or after load time in an
+  `HTMLImportsCors.whenReady(callback)` call.
+
+  NOTE: This module also supports these apis under the native implementation.
+  Therefore, if this file is loaded, the same code can be used under both
+  the polyfill and native implementation.
+ */
+
+var isIE = /Trident/.test(navigator.userAgent);
+
+// call a callback when all HTMLImportsCors in the document at call time
+// (or at least document ready) have loaded.
+// 1. ensure the document is in a ready state (has dom), then
+// 2. watch for loading of imports and call callback when done
+function whenReady(callback, doc) {
+  doc = doc || rootDocument;
+  // if document is loading, wait and try again
+  whenDocumentReady(function() {
+    watchImportsLoad(callback, doc);
+  }, doc);
+}
+
+// call the callback when the document is in a ready state (has dom)
+var requiredReadyState = isIE ? 'complete' : 'interactive';
+var READY_EVENT = 'readystatechange';
+function isDocumentReady(doc) {
+  return (doc.readyState === 'complete' ||
+      doc.readyState === requiredReadyState);
+}
+
+// call <callback> when we ensure the document is in a ready state
+function whenDocumentReady(callback, doc) {
+  if (!isDocumentReady(doc)) {
+    var checkReady = function() {
+      if (doc.readyState === 'complete' ||
+          doc.readyState === requiredReadyState) {
+        doc.removeEventListener(READY_EVENT, checkReady);
+        whenDocumentReady(callback, doc);
+      }
+    };
+    doc.addEventListener(READY_EVENT, checkReady);
+  } else if (callback) {
+    callback();
+  }
+}
+
+function markTargetLoaded(event) {
+  event.target.__loaded = true;
+}
+
+// call <callback> when we ensure all imports have loaded
+function watchImportsLoad(callback, doc) {
+  var imports = doc.querySelectorAll('link[rel=import]');
+  var parsedCount = 0, importCount = imports.length, newImports = [], errorImports = [];
+  function checkDone() {
+    if (parsedCount == importCount && callback) {
+      callback({
+        allImports: imports,
+        loadedImports: newImports,
+        errorImports: errorImports
+      });
+    }
+  }
+  function loadedImport(e) {
+    markTargetLoaded(e);
+    newImports.push(this);
+    parsedCount++;
+    checkDone();
+  }
+  function errorLoadingImport(e) {
+    errorImports.push(this);
+    parsedCount++;
+    checkDone();
+  }
+  if (importCount) {
+    for (var i=0, imp; i<importCount && (imp=imports[i]); i++) {
+      if (isImportLoaded(imp)) {
+        newImports.push(this);
+        parsedCount++;
+        checkDone();
+      } else {
+        imp.addEventListener('load', loadedImport);
+        imp.addEventListener('error', errorLoadingImport);
+      }
+    }
+  } else {
+    checkDone();
+  }
+}
+
+// NOTE: test for native imports loading is based on explicitly watching
+// all imports (see below).
+// However, we cannot rely on this entirely without watching the entire document
+// for import links. For perf reasons, currently only head is watched.
+// Instead, we fallback to checking if the import property is available
+// and the document is not itself loading.
+function isImportLoaded(link) {
+  return useNative ? link.__loaded ||
+      (link.import && link.import.readyState !== 'loading') :
+      link.__importParsed;
+}
+
+// TODO(sorvell): Workaround for
+// https://www.w3.org/Bugs/Public/show_bug.cgi?id=25007, should be removed when
+// this bug is addressed.
+// (1) Install a mutation observer to see when HTMLImportsCors have loaded
+// (2) if this script is run during document load it will watch any existing
+// imports for loading.
+//
+// NOTE: The workaround has restricted functionality: (1) it's only compatible
+// with imports that are added to document.head since the mutation observer
+// watches only head for perf reasons, (2) it requires this script
+// to run before any imports have completed loading.
+if (useNative) {
+  new MutationObserver(function(mxns) {
+    for (var i=0, l=mxns.length, m; (i < l) && (m=mxns[i]); i++) {
+      if (m.addedNodes) {
+        handleImports(m.addedNodes);
+      }
+    }
+  }).observe(document.head, {childList: true});
+
+  function handleImports(nodes) {
+    for (var i=0, l=nodes.length, n; (i<l) && (n=nodes[i]); i++) {
+      if (isImport(n)) {
+        handleImport(n);
+      }
+    }
+  }
+
+  function isImport(element) {
+    return element.localName === 'link' && element.rel === 'import';
+  }
+
+  function handleImport(element) {
+    var loaded = element.import;
+    if (loaded) {
+      markTargetLoaded({target: element});
+    } else {
+      element.addEventListener('load', markTargetLoaded);
+      element.addEventListener('error', markTargetLoaded);
+    }
+  }
+
+  // make sure to catch any imports that are in the process of loading
+  // when this script is run.
+  (function() {
+    if (document.readyState === 'loading') {
+      var imports = document.querySelectorAll('link[rel=import]');
+      for (var i=0, l=imports.length, imp; (i<l) && (imp=imports[i]); i++) {
+        handleImport(imp);
+      }
+    }
+  })();
+
+}
+
+// Fire the 'HTMLImportsCorsLoaded' event when imports in document at load time
+// have loaded. This event is required to simulate the script blocking
+// behavior of native imports. A main document script that needs to be sure
+// imports have loaded should wait for this event.
+whenReady(function(detail) {
+  window.HTMLImportsCors.ready = true;
+  window.HTMLImportsCors.readyTime = new Date().getTime();
+  var evt = rootDocument.createEvent("CustomEvent");
+  evt.initCustomEvent("HTMLImportsCorsLoaded", true, true, detail);
+  rootDocument.dispatchEvent(evt);
+});
+
+// exports
+scope.IMPORT_LINK_TYPE = IMPORT_LINK_TYPE;
+scope.useNative = useNative;
+scope.rootDocument = rootDocument;
+scope.whenReady = whenReady;
+scope.isIE = isIE;
+
+})(window.HTMLImportsCors);

--- a/src/HTMLImportsCors/boot.js
+++ b/src/HTMLImportsCors/boot.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+(function(scope){
+
+// imports
+var initializeModules = scope.initializeModules;
+var isIE = scope.isIE;
+
+/*
+NOTE: Even when native HTMLImportsCors exists, the following api is available by
+loading the polyfill. This provides api compatibility where the polyfill
+cannot be "correct":
+
+  * `document._currentScript`
+  * `HTMLImportsCorsLoaded` event
+  * `HTMLImportsCors.whenReady(callback)
+*/
+if (scope.useNative) {
+  return;
+}
+
+// Initialize polyfill modules. Note, polyfill modules are loaded but not
+// executed; this is a convenient way to control which modules run when
+// the polyfill is required and allows the polyfill to load even when it's
+// not needed.
+initializeModules();
+
+// imports
+var rootDocument = scope.rootDocument;
+
+/*
+  Bootstrap the imports machine.
+*/
+function bootstrap() {
+  window.HTMLImportsCors.importer.bootDocument(rootDocument);
+}
+
+// TODO(sorvell): SD polyfill does *not* generate mutations for nodes added
+// by the parser. For this reason, we must wait until the dom exists to
+// bootstrap.
+if (document.readyState === 'complete' ||
+    (document.readyState === 'interactive' && !window.attachEvent)) {
+  bootstrap();
+} else {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+}
+
+})(window.HTMLImportsCors);

--- a/src/HTMLImportsCors/build.json
+++ b/src/HTMLImportsCors/build.json
@@ -1,0 +1,15 @@
+[
+  "../WeakMap/WeakMap.js",
+  "../MutationObserver/MutationObserver.js",
+  "../WebComponents/dom.js",
+  "base.js",
+  "module.js",
+  "path.js",
+  "xhr.js",
+  "Loader.js",
+  "Observer.js",
+  "parser.js",
+  "importer.js",
+  "dynamic.js",
+  "boot.js"
+]

--- a/src/HTMLImportsCors/dynamic.js
+++ b/src/HTMLImportsCors/dynamic.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+// imports
+var parser = scope.parser;
+var importer = scope.importer;
+
+// dynamic
+// highlander object to manage elements dynamically added to imports
+// for any observed document, dynamic:
+// - tells the importer to load any imports that are added.
+// - tells the parser to parse any added elements that need to be parsed.
+// dynamic importer)
+var dynamic = {
+  // process (load/parse) any nodes added to imported documents.
+  added: function(nodes) {
+    var owner, parsed, loading;
+    for (var i=0, l=nodes.length, n; (i<l) && (n=nodes[i]); i++) {
+      if (!owner) {
+        owner = n.ownerDocument;
+        parsed = parser.isParsed(owner);
+      }
+      // note: the act of loading kicks the parser, so we use parseDynamic's
+      // 2nd argument to control if this added node needs to kick the parser.
+      loading = this.shouldLoadNode(n);
+      if (loading) {
+        importer.loadNode(n);
+      }
+      if (this.shouldParseNode(n) && parsed) {
+        parser.parseDynamic(n, loading);
+      }
+    }
+  },
+
+  shouldLoadNode: function(node) {
+    return (node.nodeType === 1) && matches.call(node,
+        importer.loadSelectorsForNode(node));
+  },
+
+  shouldParseNode: function(node) {
+    return (node.nodeType === 1) && matches.call(node,
+        parser.parseSelectorsForNode(node));
+  }
+
+};
+
+// let the dynamic element helper tie into the import observer.
+importer.observer.addCallback = dynamic.added.bind(dynamic);
+
+// x-plat matches
+var matches = HTMLElement.prototype.matches ||
+    HTMLElement.prototype.matchesSelector ||
+    HTMLElement.prototype.webkitMatchesSelector ||
+    HTMLElement.prototype.mozMatchesSelector ||
+    HTMLElement.prototype.msMatchesSelector;
+
+});

--- a/src/HTMLImportsCors/importer.js
+++ b/src/HTMLImportsCors/importer.js
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+// imports
+var flags = scope.flags;
+var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
+var IMPORT_SELECTOR = scope.IMPORT_SELECTOR;
+var rootDocument = scope.rootDocument;
+var Loader = scope.Loader;
+var Observer = scope.Observer;
+var parser = scope.parser;
+
+// importer
+// highlander object to manage loading of imports
+// for any document, importer:
+// - loads any linked import documents (with deduping)
+// - whenever an import is loaded, prompts the parser to try to parse
+// - observes imported documents for new elements (these are handled via the
+// dynamic importer)
+var importer = {
+
+  documents: {},
+
+  // nodes to load in the mian document
+  documentPreloadSelectors: IMPORT_SELECTOR,
+
+  // nodes to load in imports
+  importsPreloadSelectors: [
+    IMPORT_SELECTOR
+  ].join(','),
+
+  loadNode: function(node) {
+    importLoader.addNode(node);
+  },
+
+  // load all loadable elements within the parent element
+  loadSubtree: function(parent) {
+    var nodes = this.marshalNodes(parent);
+    // add these nodes to loader's queue
+    importLoader.addNodes(nodes);
+  },
+
+  marshalNodes: function(parent) {
+    // all preloadable nodes in inDocument
+    return parent.querySelectorAll(this.loadSelectorsForNode(parent));
+  },
+
+  // find the proper set of load selectors for a given node
+  loadSelectorsForNode: function(node) {
+    var doc = node.ownerDocument || node;
+    return doc === rootDocument ? this.documentPreloadSelectors :
+        this.importsPreloadSelectors;
+  },
+
+  loaded: function(url, elt, resource, err, redirectedUrl) {
+    flags.load && console.log('loaded', url, elt);
+    // store generic resource
+    // TODO(sorvell): fails for nodes inside <template>.content
+    // see https://code.google.com/p/chromium/issues/detail?id=249381.
+    elt.__resource = resource;
+    elt.__error = err;
+    if (isImportLink(elt)) {
+      var doc = this.documents[url];
+      // if we've never seen a document at this url
+      if (doc === undefined) {
+        // generate an HTMLDocument from data
+        doc = err ? null : makeDocument(resource, redirectedUrl || url);
+        if (doc) {
+          doc.__importLink = elt;
+          // note, we cannot use MO to detect parsed nodes because
+          // SD polyfill does not report these as mutations.
+          this.bootDocument(doc);
+        }
+        // cache document
+        this.documents[url] = doc;
+      }
+      // don't store import record until we're actually loaded
+      // store document resource
+      elt.__doc = doc;
+    }
+    parser.parseNext();
+  },
+
+  bootDocument: function(doc) {
+    this.loadSubtree(doc);
+    // observe documents for new elements being added
+    this.observer.observe(doc);
+    parser.parseNext();
+  },
+
+  loadedAll: function() {
+    parser.parseNext();
+  }
+
+};
+
+// loader singleton to handle loading imports
+var importLoader = new Loader(importer.loaded.bind(importer),
+    importer.loadedAll.bind(importer));
+
+// observer singleton to handle observing elements in imports
+// NOTE: the observer has a node added callback and this is set
+// by the dynamic importer module.
+importer.observer = new Observer();
+
+function isImportLink(elt) {
+  return isLinkRel(elt, IMPORT_LINK_TYPE);
+}
+
+function isLinkRel(elt, rel) {
+  return elt.localName === 'link' && elt.getAttribute('rel') === rel;
+}
+
+function hasBaseURIAccessor(doc) {
+  return !! Object.getOwnPropertyDescriptor(doc, 'baseURI');
+}
+
+function makeDocument(resource, url) {
+  // create a new HTML document
+  var doc = document.implementation.createHTMLDocument(IMPORT_LINK_TYPE);
+  // cache the new document's source url
+  doc._URL = url;
+  // establish a relative path via <base>
+  var base = doc.createElement('base');
+  base.setAttribute('href', url);
+  // add baseURI support to browsers (IE) that lack it.
+  if (!doc.baseURI && !hasBaseURIAccessor(doc)) {
+    // Use defineProperty since Safari throws an exception when using assignment.
+    Object.defineProperty(doc, 'baseURI', {value:url});
+  }
+  // ensure UTF-8 charset
+  var meta = doc.createElement('meta');
+  meta.setAttribute('charset', 'utf-8');
+
+  doc.head.appendChild(meta);
+  doc.head.appendChild(base);
+  // install html
+  doc.body.innerHTML = resource;
+  // TODO(sorvell): ideally this code is not aware of Template polyfill,
+  // but for now the polyfill needs help to bootstrap these templates
+  if (window.HTMLTemplateElement && HTMLTemplateElement.bootstrap) {
+    HTMLTemplateElement.bootstrap(doc);
+  }
+  return doc;
+}
+
+// Polyfill document.baseURI for browsers without it.
+if (!document.baseURI) {
+  var baseURIDescriptor = {
+    get: function() {
+      var base = document.querySelector('base');
+      return base ? base.href : window.location.href;
+    },
+    configurable: true
+  };
+
+  Object.defineProperty(document, 'baseURI', baseURIDescriptor);
+  Object.defineProperty(rootDocument, 'baseURI', baseURIDescriptor);
+}
+
+// exports
+scope.importer = importer;
+scope.importLoader = importLoader;
+
+});

--- a/src/HTMLImportsCors/module.js
+++ b/src/HTMLImportsCors/module.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+(function(scope) {
+
+// world's simplest module initializer
+var modules = [];
+var addModule = function(module) {
+	modules.push(module);
+};
+
+var initializeModules = function() {
+	modules.forEach(function(module) {
+		module(scope);
+	});
+};
+
+// exports
+scope.addModule = addModule;
+scope.initializeModules = initializeModules;
+
+})(window.HTMLImportsCors);
+

--- a/src/HTMLImportsCors/parser.js
+++ b/src/HTMLImportsCors/parser.js
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+// imports
+var path = scope.path;
+var rootDocument = scope.rootDocument;
+var flags = scope.flags;
+var isIE = scope.isIE;
+var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
+var IMPORT_SELECTOR = 'link[rel=' + IMPORT_LINK_TYPE + ']';
+
+// importParser
+// highlander object to manage parsing of imports
+// parses import related elements and ensures proper parse order
+// parse order is enforced by crawling the tree and monitoring which elements
+// have been parsed;
+// elements can be dynamically added to imports. These are maintained in a
+// separate queue and parsed after all other elements.
+var importParser = {
+
+  // parse selectors for main document elements
+  documentSelectors: IMPORT_SELECTOR,
+
+  // parse selectors for import document elements
+  importsSelectors: [
+    IMPORT_SELECTOR,
+    'link[rel=stylesheet]:not([type])',
+    'style:not([type])',
+    'script:not([type])',
+    'script[type="application/javascript"]',
+    'script[type="text/javascript"]'
+  ].join(','),
+
+  map: {
+    link: 'parseLink',
+    script: 'parseScript',
+    style: 'parseStyle'
+  },
+
+  dynamicElements: [],
+
+  // try to parse the next import in the tree
+  parseNext: function() {
+    var next = this.nextToParse();
+    if (next) {
+      this.parse(next);
+    }
+  },
+
+  parse: function(elt) {
+    if (this.isParsed(elt)) {
+      flags.parse && console.log('[%s] is already parsed', elt.localName);
+      return;
+    }
+    var fn = this[this.map[elt.localName]];
+    if (fn) {
+      this.markParsing(elt);
+      fn.call(this, elt);
+    }
+  },
+
+  // marks an element for dynamic parsing and attempts to parse the next element
+  parseDynamic: function(elt, quiet) {
+    this.dynamicElements.push(elt);
+    if (!quiet) {
+      this.parseNext();
+    }
+  },
+
+  // only 1 element may be parsed at a time; parsing is async so each
+  // parsing implementation must inform the system that parsing is complete
+  // via markParsingComplete.
+  // To prompt the system to parse the next element, parseNext should then be
+  // called.
+  // Note, parseNext used to be included at the end of markParsingComplete, but
+  // we must not do this so that, for example, we can (1) mark parsing complete
+  // then (2) fire an import load event, and then (3) parse the next resource.
+  markParsing: function(elt) {
+    flags.parse && console.log('parsing', elt);
+    this.parsingElement = elt;
+  },
+
+  markParsingComplete: function(elt) {
+    elt.__importParsed = true;
+    this.markDynamicParsingComplete(elt);
+    if (elt.__importElement) {
+      elt.__importElement.__importParsed = true;
+      this.markDynamicParsingComplete(elt.__importElement);
+    }
+    this.parsingElement = null;
+    flags.parse && console.log('completed', elt);
+  },
+
+  markDynamicParsingComplete: function(elt) {
+    var i = this.dynamicElements.indexOf(elt);
+    if (i >= 0) {
+      this.dynamicElements.splice(i, 1);
+    }
+  },
+
+  parseImport: function(elt) {
+    elt.import = elt.__doc;
+    if (window.HTMLImportsCors.__importsParsingHook) {
+      window.HTMLImportsCors.__importsParsingHook(elt);
+    }
+    if (elt.import) {
+      elt.import.__importParsed = true;
+    }
+    this.markParsingComplete(elt);
+    // fire load event
+    if (elt.__resource && !elt.__error) {
+      elt.dispatchEvent(new CustomEvent('load', {bubbles: false}));
+    } else {
+      elt.dispatchEvent(new CustomEvent('error', {bubbles: false}));
+    }
+    // TODO(sorvell): workaround for Safari addEventListener not working
+    // for elements not in the main document.
+    if (elt.__pending) {
+      var fn;
+      while (elt.__pending.length) {
+        fn = elt.__pending.shift();
+        if (fn) {
+          fn({target: elt});
+        }
+      }
+    }
+    this.parseNext();
+  },
+
+  parseLink: function(linkElt) {
+    if (nodeIsImport(linkElt)) {
+      this.parseImport(linkElt);
+    } else {
+      // make href absolute
+      linkElt.href = linkElt.href;
+      this.parseGeneric(linkElt);
+    }
+  },
+
+  parseStyle: function(elt) {
+    // TODO(sorvell): style element load event can just not fire so clone styles
+    var src = elt;
+    elt = cloneStyle(elt);
+    src.__appliedElement = elt;
+    elt.__importElement = src;
+    this.parseGeneric(elt);
+  },
+
+  parseGeneric: function(elt) {
+    this.trackElement(elt);
+    this.addElementToDocument(elt);
+  },
+
+  rootImportForElement: function(elt) {
+    var n = elt;
+    while (n.ownerDocument.__importLink) {
+      n = n.ownerDocument.__importLink;
+    }
+    return n;
+  },
+
+  addElementToDocument: function(elt) {
+    var port = this.rootImportForElement(elt.__importElement || elt);
+    port.parentNode.insertBefore(elt, port);
+  },
+
+  // tracks when a loadable element has loaded
+  trackElement: function(elt, callback) {
+    var self = this;
+    var done = function(e) {
+      // make sure we don't get multiple load/error signals (FF seems to do
+      // this sometimes when <style> elments change)
+      elt.removeEventListener('load', done);
+      elt.removeEventListener('error', done);
+      if (callback) {
+        callback(e);
+      }
+      self.markParsingComplete(elt);
+      self.parseNext();
+    };
+    elt.addEventListener('load', done);
+    elt.addEventListener('error', done);
+
+    // NOTE: IE does not fire "load" event for styles that have already loaded
+    // This is in violation of the spec, so we try our hardest to work around it
+    if (isIE && elt.localName === 'style') {
+      var fakeLoad = false;
+      // If there's not @import in the textContent, assume it has loaded
+      if (elt.textContent.indexOf('@import') == -1) {
+        fakeLoad = true;
+      // if we have a sheet, we have been parsed
+      } else if (elt.sheet) {
+        fakeLoad = true;
+        var csr = elt.sheet.cssRules;
+        var len = csr ? csr.length : 0;
+        // search the rules for @import's
+        for (var i = 0, r; (i < len) && (r = csr[i]); i++) {
+          if (r.type === CSSRule.IMPORT_RULE) {
+            // if every @import has resolved, fake the load
+            fakeLoad = fakeLoad && Boolean(r.styleSheet);
+          }
+        }
+      }
+      // dispatch a fake load event and continue parsing
+      if (fakeLoad) {
+        // Fire async, to prevent reentrancy
+        setTimeout(function() {
+          elt.dispatchEvent(new CustomEvent('load', {bubbles: false}));
+        });
+      }
+    }
+  },
+
+  // NOTE: execute scripts by injecting them and watching for the load/error
+  // event. Inline scripts are handled via dataURL's because browsers tend to
+  // provide correct parsing errors in this case. If this has any compatibility
+  // issues, we can switch to injecting the inline script with textContent.
+  parseScript: function(scriptElt) {
+    var script = document.createElement('script');
+    script.__importElement = scriptElt;
+    script.src = scriptElt.src ? scriptElt.src :
+        generateScriptDataUrl(scriptElt);
+    // keep track of executing script to help polyfill `document.currentScript`
+    scope.currentScript = scriptElt;
+    this.trackElement(script, function(e) {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+      scope.currentScript = null;
+    });
+    this.addElementToDocument(script);
+  },
+
+  // determine the next element in the tree which should be parsed
+  // crawl the document tree to find the next unparsed element
+  // then process any dynamically added elements (these should process in 'add'
+  // order.
+  nextToParse: function() {
+    this._mayParse = [];
+    return !this.parsingElement && (this.nextToParseInDoc(rootDocument) ||
+        this.nextToParseDynamic());
+  },
+
+  nextToParseInDoc: function(doc, link) {
+    // use `marParse` list to avoid looping into the same document again
+    // since it could cause an iloop.
+    if (doc && this._mayParse.indexOf(doc) < 0) {
+      this._mayParse.push(doc);
+      var nodes = doc.querySelectorAll(this.parseSelectorsForNode(doc));
+      for (var i=0, l=nodes.length, n; (i<l) && (n=nodes[i]); i++) {
+        if (!this.isParsed(n)) {
+          if (this.hasResource(n)) {
+            return nodeIsImport(n) ? this.nextToParseInDoc(n.__doc, n) : n;
+          } else {
+            return;
+          }
+        }
+      }
+    }
+    // all nodes have been parsed, ready to parse import, if any
+    return link;
+  },
+
+  // note dynamically added elements are stored in a separate queue
+  nextToParseDynamic: function() {
+    return this.dynamicElements[0];
+  },
+
+  // return the set of parse selectors relevant for this node.
+  parseSelectorsForNode: function(node) {
+    var doc = node.ownerDocument || node;
+    return doc === rootDocument ? this.documentSelectors :
+        this.importsSelectors;
+  },
+
+  isParsed: function(node) {
+    return node.__importParsed;
+  },
+
+  needsDynamicParsing: function(elt) {
+    return (this.dynamicElements.indexOf(elt) >= 0);
+  },
+
+  hasResource: function(node) {
+    if (nodeIsImport(node) && (node.__doc === undefined)) {
+      return false;
+    }
+    return true;
+  }
+
+};
+
+function nodeIsImport(elt) {
+  return (elt.localName === 'link') && (elt.rel === IMPORT_LINK_TYPE);
+}
+
+function generateScriptDataUrl(script) {
+  var scriptContent = generateScriptContent(script);
+  return 'data:text/javascript;charset=utf-8,' + encodeURIComponent(scriptContent);
+}
+
+function generateScriptContent(script) {
+  return script.textContent + generateSourceMapHint(script);
+}
+
+// calculate source map hint
+function generateSourceMapHint(script) {
+  var owner = script.ownerDocument;
+  owner.__importedScripts = owner.__importedScripts || 0;
+  var moniker = script.ownerDocument.baseURI;
+  var num = owner.__importedScripts ? '-' + owner.__importedScripts : '';
+  owner.__importedScripts++;
+  return '\n//# sourceURL=' + moniker + num + '.js\n';
+}
+
+// style/stylesheet handling
+
+// clone style with proper path resolution for main document
+// NOTE: styles are the only elements that require direct path fixup.
+function cloneStyle(style) {
+  var clone = style.ownerDocument.createElement('style');
+  clone.textContent = style.textContent;
+  path.resolveUrlsInStyle(clone);
+  return clone;
+}
+
+// exports
+scope.parser = importParser;
+scope.IMPORT_SELECTOR = IMPORT_SELECTOR;
+
+});

--- a/src/HTMLImportsCors/path.js
+++ b/src/HTMLImportsCors/path.js
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+var CSS_URL_REGEXP = /(url\()([^)]*)(\))/g;
+var CSS_IMPORT_REGEXP = /(@import[\s]+(?!url\())([^;]*)(;)/g;
+
+// path fixup: style elements in imports must be made relative to the main
+// document. We fixup url's in url() and @import.
+var path = {
+
+  resolveUrlsInStyle: function(style, linkUrl) {
+    var doc = style.ownerDocument;
+    var resolver = doc.createElement('a');
+    style.textContent = this.resolveUrlsInCssText(style.textContent, linkUrl, resolver);
+    return style;
+  },
+
+  resolveUrlsInCssText: function(cssText, linkUrl, urlObj) {
+    var r = this.replaceUrls(cssText, urlObj, linkUrl, CSS_URL_REGEXP);
+    r = this.replaceUrls(r, urlObj, linkUrl, CSS_IMPORT_REGEXP);
+    return r;
+  },
+
+  replaceUrls: function(text, urlObj, linkUrl, regexp) {
+    return text.replace(regexp, function(m, pre, url, post) {
+      var urlPath = url.replace(/["']/g, '');
+      if (linkUrl) {
+        urlPath = (new URL(urlPath, linkUrl)).href;
+      }
+      urlObj.href = urlPath;
+      urlPath = urlObj.href;
+      return pre + '\'' + urlPath + '\'' + post;
+    });
+  }
+
+};
+
+// exports
+scope.path = path;
+
+});

--- a/src/HTMLImportsCors/xhr.js
+++ b/src/HTMLImportsCors/xhr.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+window.HTMLImportsCors.addModule(function(scope) {
+
+/*
+  xhr processor.
+*/
+var xhr = {
+  async: true,
+
+  ok: function(request) {
+    return (request.status >= 200 && request.status < 300)
+        || (request.status === 304)
+        || (request.status === 0);
+  },
+
+  load: function(url, next, nextContext) {
+    var request = new XMLHttpRequest();
+    if (scope.flags.debug || scope.flags.bust) {
+      url += '?' + Math.random();
+    }
+    request.open('GET', url, xhr.async);
+    request.withCredentials = scope.flags.withCredentials;
+    request.addEventListener('readystatechange', function(e) {
+      if (request.readyState === 4) {
+        // Servers redirecting an import can add a Location header to help us
+        // polyfill correctly.
+        var redirectedUrl = null;
+        try {
+          var locationHeader = request.getResponseHeader("Location");
+          if (locationHeader) {
+            redirectedUrl = (locationHeader.substr( 0, 1 ) === "/")
+              ? location.origin + locationHeader  // Location is a relative path
+              : locationHeader;                   // Full path
+          }
+        } catch ( e ) {
+            console.error( e.message );
+        }
+        next.call(nextContext, !xhr.ok(request) && request,
+            request.response || request.responseText, redirectedUrl);
+      }
+    });
+    request.send();
+    return request;
+  },
+
+  loadDocument: function(url, next, nextContext) {
+    this.load(url, next, nextContext).responseType = 'document';
+  }
+
+};
+
+// exports
+scope.xhr = xhr;
+
+});

--- a/src/WebComponents/build.json
+++ b/src/WebComponents/build.json
@@ -7,6 +7,7 @@
   "shadowdom.js",
   "../URL/URL.js",
   "../HTMLImports/build.json",
+  "../HTMLImportsCors/build.json",
   "../CustomElements/build.json",
   "lang.js",
   "dom.js",


### PR DESCRIPTION
This pr is simply for discussion. It is an implementation of html imports supporting cors `withCredentials` to retrieve cross domain resources that require an authentication session using a html import

There are only two changes to `HTMLImport`:

`diff src/HTMLImports src/HTMLImportsCors`:

```
27c27
< var IMPORT_LINK_TYPE = 'import';

---
> var IMPORT_LINK_TYPE = 'import-cors';
29a30
>     request.withCredentials = scope.flags.withCredentials;
```

I've added `HTMLImportCors` as it was the easiest way to not replace `HTMLImport` on platforms that need the polyfill. Obviously much duplication could be avoided with a small amount of effort.

It would be great if there is a better solution for this problem in general, if anyone has suggestions?

related: https://github.com/w3c/webcomponents/issues/216
