### PR TITLE
V1: Execute onload callback for empty resources

### DIFF
--- a/src/HTMLImports/Loader.js
+++ b/src/HTMLImports/Loader.js
@@ -69,7 +69,7 @@ Loader.prototype = {
       return true;
     }
     var resource;
-    if (this.cache[url]) {
+    if (this.cache[url] != undefined) {
       this.onload(url, elt, this.cache[url]);
       // finished this transaction
       this.tail();

--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -116,7 +116,7 @@ var importParser = {
     }
     this.markParsingComplete(elt);
     // fire load event
-    if (elt.__resource && !elt.__error) {
+    if (elt.__resource != undefined && !elt.__error) {
       elt.dispatchEvent(new CustomEvent('load', {bubbles: false}));
     } else {
       elt.dispatchEvent(new CustomEvent('error', {bubbles: false}));

--- a/src/ShadowCSS/ShadowCSS.js
+++ b/src/ShadowCSS/ShadowCSS.js
@@ -739,7 +739,7 @@ if (window.ShadowDOMPolyfill) {
           originalParseGeneric.call(this, elt);
           return;
         }
-        if (elt.__resource) {
+        if (elt.__resource != undefined) {
           style = elt.ownerDocument.createElement('style');
           style.textContent = elt.__resource;
         }
@@ -767,7 +767,7 @@ if (window.ShadowDOMPolyfill) {
       HTMLImports.parser.hasResource = function(node) {
         if (node.localName === 'link' && node.rel === 'stylesheet' &&
             node.hasAttribute(SHIM_ATTRIBUTE)) {
-          return (node.__resource);
+          return (node.__resource != undefined);
         } else {
           return hasResource.call(this, node);
         }

--- a/tests/HTMLImports/html/load-empty.html
+++ b/tests/HTMLImports/html/load-empty.html
@@ -17,8 +17,8 @@
         function importLoaded(event) {
           window.loadEvents++;
           if (event.type === 'load' && event.target.import) {
-            var s = event.target.import.querySelector('script');
-            chai.assert.ok(s, 'load event target can be used to find element in import');
+            var emptyImport = event.target.import;
+            chai.assert.ok(emptyImport instanceof Document, 'load event target can be used to find imported document');
           }
         }
 

--- a/tests/HTMLImports/html/load-empty.html
+++ b/tests/HTMLImports/html/load-empty.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>load event Test for empty resources</title>
+    <script>
+      window.loadEvents = 0;
+      (function() {
+        function importLoaded(event) {
+          window.loadEvents++;
+          if (event.type === 'load' && event.target.import) {
+            var s = event.target.import.querySelector('script');
+            chai.assert.ok(s, 'load event target can be used to find element in import');
+          }
+        }
+
+        window.importLoaded = importLoaded;
+      })();
+    </script>
+    <script src="../../../src/HTMLImports/HTMLImports.js"></script>
+    <script src="../../../../web-component-tester/browser.js"></script>
+    <link rel="import" href="imports/load-empty.html" onload="importLoaded(event)">
+  </head>
+  <body>
+    <script>
+      test('load empty resource', function() {
+        chai.assert.equal(loadEvents, 1, 'expected # of load events');
+      });
+    </script>
+  </body>
+</html>

--- a/tests/HTMLImports/runner.html
+++ b/tests/HTMLImports/runner.html
@@ -30,6 +30,7 @@
   'html/load.html',
   'html/load-404.html',
   'html/load-loop.html',
+  'html/load-empty.html',
   'html/base/load-base.html',
   'html/currentScript.html',
   'html/dedupe.html',


### PR DESCRIPTION
This is just a rebased version of old PR for master branch https://github.com/webcomponents/webcomponentsjs/pull/536

> 2xx with empty content is still a valid document, that was successfully loaded
> 
> Fix for webcomponents/webcomponentsjs#535

//cc @garlicnation @tjsavage 
