### PR TITLE
Event handler bug

### DIFF
--- a/src/ShadowDOM/wrappers/events.js
+++ b/src/ShadowDOM/wrappers/events.js
@@ -777,7 +777,7 @@
       listeners.push(listener);
 
       var target = getTargetToListenAt(this);
-      target.addEventListener_(type, dispatchOriginalEvent, true);
+      target.addEventListener_(type, dispatchOriginalEvent, capture);
     },
     removeEventListener: function(type, fun, capture) {
       capture = Boolean(capture);
@@ -797,7 +797,7 @@
 
       if (found && count === 1) {
         var target = getTargetToListenAt(this);
-        target.removeEventListener_(type, dispatchOriginalEvent, true);
+        target.removeEventListener_(type, dispatchOriginalEvent, capture);
       }
     },
     dispatchEvent: function(event) {

--- a/tests/WebComponents/html/ce-event-handlers-lite.html
+++ b/tests/WebComponents/html/ce-event-handlers-lite.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title></title>
+    <meta charset="UTF-8">
+    <script src="../../../../web-component-tester/browser.js"></script>
+    <script src="../../../webcomponents-lite.js"></script>
+  </head>
+  <body>
+      <script src="../js/ce-event-handlers.js"></script>
+  </body>
+</html>

--- a/tests/WebComponents/html/ce-event-handlers.html
+++ b/tests/WebComponents/html/ce-event-handlers.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title></title>
+    <meta charset="UTF-8">
+    <script src="../../../../web-component-tester/browser.js"></script>
+    <script src="../../../webcomponents.js"></script>
+  </head>
+  <body>
+      <script src="../js/ce-event-handlers.js"></script>
+  </body>
+</html>

--- a/tests/WebComponents/js/ce-event-handlers.js
+++ b/tests/WebComponents/js/ce-event-handlers.js
@@ -1,0 +1,32 @@
+test('Event binding works with both variations of useCapture', function(done) {
+    var p = Object.create(HTMLElement.prototype);
+    p.attachedCallback = function() {
+        var handler = sinon.stub();
+        document.addEventListener('click', handler, true);
+        document.body.click();
+        assert.ok(handler.called);
+        handler.reset();
+
+        var handler2 = sinon.stub();
+        document.addEventListener('click', handler2);
+        document.body.click();
+        assert.ok(handler.called);
+        assert.ok(handler2.called);
+        handler.reset();
+        handler2.reset();
+
+        document.removeEventListener('click', handler2);
+        document.body.click();
+        assert.ok(handler.called);
+        assert.notOk(handler2.called);
+
+        done();
+    }
+
+    document.registerElement('my-element', {
+        prototype: p
+    });
+
+    var el = document.createElement('my-element');
+    document.body.appendChild(el);
+})

--- a/tests/WebComponents/runner.html
+++ b/tests/WebComponents/runner.html
@@ -20,6 +20,8 @@
     'html/web-components.html',
     'html/smoke.html',
     'html/smoke.html?shadow=native',
+    'html/ce-event-handlers-lite.html',
+    'html/ce-event-handlers.html',
     'html/ce-import.html',
     'html/ce-import.html?shadow=native',
     'html/ce-upgradedocumenttree.html',


### PR DESCRIPTION
`target.addEventListener_(type, dispatchOriginalEvent, true)` is used to bind listeners to the target regardless if `useCapture` is true. That's ok until you go to remove:

```
if (found && count === 1) {
    var target = getTargetToListenAt(this);
    target.removeEventListener_(type, dispatchOriginalEvent, true);
}
```

This means if you bind an event listener using `useCapture: true`, bind another event listener using `useCapture: false`, and then remove the second listener it will stop listening to the target element even though we still expect to have the first event listener bound.
