### PR TITLE
added support for WebKitMutationObserver

### DIFF
--- a/src/MutationObserver/MutationObserver.js
+++ b/src/MutationObserver/MutationObserver.js
@@ -567,9 +567,13 @@
   global.JsMutationObserver = JsMutationObserver;
 
   if (!global.MutationObserver) {
-    global.MutationObserver = JsMutationObserver;
-    // Explicltly mark MO as polyfilled for user reference.
-    JsMutationObserver._isPolyfilled = true;
+    if (global.WebKitMutationObserver) {
+      global.MutationObserver = global.WebKitMutationObserver;
+    } else {
+      global.MutationObserver = JsMutationObserver;
+      // Explicltly mark MO as polyfilled for user reference.
+      JsMutationObserver._isPolyfilled = true;
+    }
   }
 
 })(self);


### PR DESCRIPTION
Is there a reason you don't support WebKitMutationObserver?  It's the only MutationObserver available on my iPad which is only just short of current iOS (9.3.3 I believe), and appears to work fine.

re: guidelines, permission slips, etc, it's a 4 word change, if you count `global` as a changed word.  Seriously.
