### PR TITLE
fixed memory leak while importing html elements in IE

### DIFF
--- a/src/CustomElements/observe.js
+++ b/src/CustomElements/observe.js
@@ -252,9 +252,8 @@ function takeRecords(node) {
     node = node.parentNode;
   }
 
-  // this needs to be on head or it will leak in IE
-  // IE does not like it when you have non-standard attributes on root dom's, so put
-  // the observer on the head element
+  // The node is a ShadowRoot, an IE will have a memory leak if you put the observer
+  // directly on the ShadowRoot, so put it on the head so it does not leak
   var observer = node.head.__observer;
   if (observer) {
     handler(node, observer.takeRecords());
@@ -263,7 +262,6 @@ function takeRecords(node) {
 }
 
 var forEach = Array.prototype.forEach.call.bind(Array.prototype.forEach);
-
 
 // observe a node tree; bail if it's already being observed.
 function observe(inRoot) {
@@ -276,8 +274,9 @@ function observe(inRoot) {
   // Give the handler access to the root so that an 'in document' check can
   // be done.
 
-  // IE requires that you put an observer on child elements of the DOM or it will leak
-  // at this point inRoot == #document
+  // originally the observer was on the ShadowRoot (inRoot) (single observer); 
+  // this causes a memory leak within IE.  To fix this, we must put a an observer
+  // on both the head and body nodes on the ShadowRoot
   var observer = new MutationObserver(handler.bind(this, inRoot));
   observer.observe(inRoot.head, {childList: true, subtree: true});
   observer.observe(inRoot.body, {childList: true, subtree: true});

--- a/src/CustomElements/observe.js
+++ b/src/CustomElements/observe.js
@@ -251,7 +251,7 @@ function takeRecords(node) {
   while (node.parentNode) {
     node = node.parentNode;
   }
-  var observer = node.__observer;
+  var observer = node.head.__observer;
   if (observer) {
     handler(node, observer.takeRecords());
     takeMutations();
@@ -263,7 +263,7 @@ var forEach = Array.prototype.forEach.call.bind(Array.prototype.forEach);
 
 // observe a node tree; bail if it's already being observed.
 function observe(inRoot) {
-  if (inRoot.__observer) {
+  if (inRoot.head.__observer) {
     return;
   }
   // For each ShadowRoot, we create a new MutationObserver, so the root can be
@@ -271,8 +271,9 @@ function observe(inRoot) {
   // Give the handler access to the root so that an 'in document' check can
   // be done.
   var observer = new MutationObserver(handler.bind(this, inRoot));
-  observer.observe(inRoot, {childList: true, subtree: true});
-  inRoot.__observer = observer;
+  observer.observe(inRoot.head, {childList: true, subtree: true});
+  observer.observe(inRoot.body, {childList: true, subtree: true});
+  inRoot.head.__observer = observer;
 }
 
 // upgrade an entire document and observe it for elements changes.

--- a/src/CustomElements/observe.js
+++ b/src/CustomElements/observe.js
@@ -263,7 +263,7 @@ var forEach = Array.prototype.forEach.call.bind(Array.prototype.forEach);
 
 // observe a node tree; bail if it's already being observed.
 function observe(inRoot) {
-  if (inRoot.head.__observer) {
+  if (inRoot && inRoot.head && inRoot.head.__observer) {
     return;
   }
   // For each ShadowRoot, we create a new MutationObserver, so the root can be

--- a/src/CustomElements/observe.js
+++ b/src/CustomElements/observe.js
@@ -251,6 +251,10 @@ function takeRecords(node) {
   while (node.parentNode) {
     node = node.parentNode;
   }
+
+  // this needs to be on head or it will leak in IE
+  // IE does not like it when you have non-standard attributes on root dom's, so put
+  // the observer on the head element
   var observer = node.head.__observer;
   if (observer) {
     handler(node, observer.takeRecords());
@@ -263,6 +267,7 @@ var forEach = Array.prototype.forEach.call.bind(Array.prototype.forEach);
 
 // observe a node tree; bail if it's already being observed.
 function observe(inRoot) {
+  
   if (inRoot && inRoot.head && inRoot.head.__observer) {
     return;
   }
@@ -270,9 +275,17 @@ function observe(inRoot) {
   // garbage collected once all references to the `inRoot` node are gone.
   // Give the handler access to the root so that an 'in document' check can
   // be done.
+
+  // IE requires that you put an observer on child elements of the DOM or it will leak
+  // at this point inRoot == #document
   var observer = new MutationObserver(handler.bind(this, inRoot));
   observer.observe(inRoot.head, {childList: true, subtree: true});
   observer.observe(inRoot.body, {childList: true, subtree: true});
+
+  // this needs to be on head or it will leak in IE
+  // IE does not like it when you have non-standard attributes on root dom's, so put
+  // the observer on the head element
+  // this is used to check if the observer has been attached already (above)
   inRoot.head.__observer = observer;
 }
 

--- a/src/HTMLImports/Observer.js
+++ b/src/HTMLImports/Observer.js
@@ -40,7 +40,8 @@ Observer.prototype = {
   },
 
   observe: function(root) {
-    this.mo.observe(root, {childList: true, subtree: true});
+    this.mo.observe(root.head, {childList: true, subtree: true});
+    this.mo.observe(root.body, {childList: true, subtree: true});
   }
 
 };

--- a/src/HTMLImports/Observer.js
+++ b/src/HTMLImports/Observer.js
@@ -40,6 +40,8 @@ Observer.prototype = {
   },
 
   observe: function(root) {
+    // IE will leak if you put an observer on a root shadow document
+    // so observe changes to both the head and body
     this.mo.observe(root.head, {childList: true, subtree: true});
     this.mo.observe(root.body, {childList: true, subtree: true});
   }

--- a/src/HTMLImports/importer.js
+++ b/src/HTMLImports/importer.js
@@ -74,6 +74,8 @@ var importer = {
         // generate an HTMLDocument from data
         doc = err ? null : makeDocument(resource, redirectedUrl || url);
         if (doc) {
+          // IE will leak if you put the node directly on the shadow dom
+          // instead appending to head for reference
           doc.head.__importLink = elt;
           // note, we cannot use MO to detect parsed nodes because
           // SD polyfill does not report these as mutations.

--- a/src/HTMLImports/importer.js
+++ b/src/HTMLImports/importer.js
@@ -74,7 +74,7 @@ var importer = {
         // generate an HTMLDocument from data
         doc = err ? null : makeDocument(resource, redirectedUrl || url);
         if (doc) {
-          doc.__importLink = elt;
+          doc.head.__importLink = elt;
           // note, we cannot use MO to detect parsed nodes because
           // SD polyfill does not report these as mutations.
           this.bootDocument(doc);

--- a/src/HTMLImports/importer.js
+++ b/src/HTMLImports/importer.js
@@ -74,8 +74,8 @@ var importer = {
         // generate an HTMLDocument from data
         doc = err ? null : makeDocument(resource, redirectedUrl || url);
         if (doc) {
-          // IE will leak if you put the node directly on the shadow dom
-          // instead appending to head for reference
+          // IE will leak if you put the node directly on the ShadowRoot (doc)
+          // instead appending to ShadowRoot head for reference
           doc.head.__importLink = elt;
           // note, we cannot use MO to detect parsed nodes because
           // SD polyfill does not report these as mutations.

--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -161,8 +161,8 @@ var importParser = {
 
   rootImportForElement: function(elt) {
     var n = elt;
-    while (n.ownerDocument.__importLink) {
-      n = n.ownerDocument.__importLink;
+    while (n.ownerDocument.head.__importLink) {
+      n = n.ownerDocument.head.__importLink;
     }
     return n;
   },

--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -161,6 +161,8 @@ var importParser = {
 
   rootImportForElement: function(elt) {
     var n = elt;
+    // IE will leak if you put the import link directly on the ownerDocument (shadow root)
+    // so the link is appended on the head element.
     while (n.ownerDocument.head.__importLink) {
       n = n.ownerDocument.head.__importLink;
     }

--- a/src/ShadowDOM/wrappers/Element.js
+++ b/src/ShadowDOM/wrappers/Element.js
@@ -76,6 +76,8 @@
       var renderer = scope.getRendererForHost(this);
       renderer.invalidate();
 
+      // This is needed for IE - if you put elements directly on the root shadow
+      // IE will leak, create head and body so we can append observers, etc.
       newShadowRoot.head = document.createElement('head');
       newShadowRoot.body = document.createElement('body');
 

--- a/src/ShadowDOM/wrappers/Element.js
+++ b/src/ShadowDOM/wrappers/Element.js
@@ -76,6 +76,9 @@
       var renderer = scope.getRendererForHost(this);
       renderer.invalidate();
 
+      newShadowRoot.head = document.createElement('head');
+      newShadowRoot.body = document.createElement('body');
+
       return newShadowRoot;
     },
 

--- a/tests/HTMLImports/html/dynamic-all-imports-detail.html
+++ b/tests/HTMLImports/html/dynamic-all-imports-detail.html
@@ -46,11 +46,16 @@
 
       test('HTMLImports whenready detail', function(done) {
         HTMLImports.whenReady(function(detail) {
-          chai.assert.equal(detail.allImports.length, 2);
-          chai.assert.equal(detail.loadedImports.length, 2);
 
-          chai.expect(detail.allImports[0].href).to.contain('imports/load-1.html');
-          chai.expect(detail.allImports[1].href).to.contain('imports/load-2.html');
+          var allImports = document.querySelectorAll('link[rel="import"]');
+
+          chai.assert.equal(detail.allImports.length, allImports.length);
+          chai.assert.equal(detail.loadedImports.length, allImports.length);
+
+          var importsArray = Array.prototype.slice.call(detail.allImports);
+
+          chai.expect(importsArray.filter(function(el){ return el.href.indexOf('imports/load-1.html') >= 0;}));
+          chai.expect(importsArray.filter(function(el){ return el.href.indexOf('imports/load-2.html') >= 0;}));
 
           done()
         });

--- a/tests/HTMLImports/html/dynamic-errors-detail.html
+++ b/tests/HTMLImports/html/dynamic-errors-detail.html
@@ -46,9 +46,10 @@
 
       test('HTMLImports whenready errors', function(done) {
         HTMLImports.whenReady(function(detail) {
-          chai.assert.equal(detail.allImports.length, 2);
+          var allImports = document.querySelectorAll('link[rel="import"]');
+          chai.assert.equal(detail.allImports.length, allImports.length);
           chai.assert.equal(detail.errorImports.length, 1);
-          chai.assert.equal(detail.loadedImports.length, 1);
+          chai.assert.equal(detail.loadedImports.length, allImports.length - 1);
 
           var errorImport = detail.errorImports[0];
           chai.expect(errorImport.href).to.contain('imports/load-does-not-exist.html');

--- a/tests/HTMLImports/html/load-404.html
+++ b/tests/HTMLImports/html/load-404.html
@@ -40,7 +40,7 @@
 
         function check() {
           clearTimeout(timeout);
-          chai.assert.equal(document.querySelector('link').import, null, '404\'d link.import is null');
+          chai.assert.equal(document.querySelector('link[href="imports/404-1.html"]').import, null, '404\'d link.import is null');
           chai.assert.equal(errors, 2, '404\'d generate error event');
           done();
         }

--- a/tests/WebComponents/html/smoke.html
+++ b/tests/WebComponents/html/smoke.html
@@ -20,7 +20,9 @@
     <x-foo>plain</x-foo>
     <button is="x-baz">plain</button>
     <script>
+      var isNativeShadowDomSupported;
       test('smoke', function(done) {
+        isNativeShadowDomSupported = !!unwrap(document.createElement('div')).createShadowRoot;
         var p = Object.create(HTMLElement.prototype);
         p.createdCallback = function() {
           this.textContent = 'custom!';
@@ -57,8 +59,13 @@
           done();
         }
         var ob = new MutationObserver(handler);
-        ob.observe(root, {childList: true, subtree: true});
-        root.appendChild(xzot);
+        if( isNativeShadowDomSupported ) {
+          ob.observe(root, {childList: true, subtree: true});
+          root.appendChild(xzot);
+        } else {
+          ob.observe(root.body, {childList: true, subtree: true});
+          root.body.appendChild(xzot);
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
541 - fixed ie memory leak when importing multiple imports

```
<!-- import.html -->

<link rel="import" href="/assets/paper-something/paper-something.html" />

<!-- index.html -->

<html><head></head><body>
<link rel="import" href="/import.html" />
</body></html>
```

this wil no longer leak in IE 11
