### PR TITLE
Only dispatch load event when import was successful

### DIFF
--- a/src/HTMLImports/parser.js
+++ b/src/HTMLImports/parser.js
@@ -116,7 +116,7 @@ var importParser = {
     }
     this.markParsingComplete(elt);
     // fire load event
-    if (elt.__resource && !elt.__error) {
+    if (elt.__resource && !elt.__error && elt.import) {
       elt.dispatchEvent(new CustomEvent('load', {bubbles: false}));
     } else {
       elt.dispatchEvent(new CustomEvent('error', {bubbles: false}));

--- a/tests/HTMLImports/html/HTMLImports.html
+++ b/tests/HTMLImports/html/HTMLImports.html
@@ -41,6 +41,148 @@
         });
 
       });
+
+      test('load event is fired when loading a new branch', function(done) {
+        var link = document.createElement('link');
+        link.rel = 'import';
+        link.href= 'imports/load-3.html';
+
+        var clear, onload, onerror;
+
+        clear = function() {
+          link.removeEventListener('load', onload);
+          link.removeEventListener('error', onerror);
+          document.head.removeChild(link);
+        }
+
+        onload = function() {
+          clear();
+          done();
+        }
+
+        onerror = function() {
+          clear();
+          chai.assert.fail('error event', 'load event', 'error event should not be fired');
+        }
+
+        link.addEventListener('load', onload);
+        link.addEventListener('error', onerror);
+
+        document.head.appendChild(link);
+
+      });
+
+      test('load event is fired when loading the same location twice', function(done) {
+
+        var createImportLink = function(done) {
+
+          var link = document.createElement('link');
+          link.rel = 'import';
+          link.href= 'imports/load-4.html';
+
+          var clear, onload, onerror;
+
+          clear = function() {
+            link.removeEventListener('load', onload);
+            link.removeEventListener('error', onerror);
+            document.head.removeChild(link);
+          }
+
+          onload = function() {
+            clear();
+            done();
+          }
+
+          onerror = function() {
+            clear();
+            chai.assert.fail('error event', 'load event', 'error event should not be fired');
+          }
+
+          link.addEventListener('load', onload);
+          link.addEventListener('error', onerror);
+
+          document.head.appendChild(link);
+
+        }
+
+        createImportLink(function() {
+          createImportLink(function() {
+            done();
+          });
+        });
+
+      });
+
+      test('error event is fired when loading a new branch failed', function(done) {
+        var link = document.createElement('link');
+        link.rel = 'import';
+        link.href= 'imports/error-3.html';
+
+        var clear, onload, onerror;
+
+        clear = function() {
+          link.removeEventListener('load', onload);
+          link.removeEventListener('error', onerror);
+          document.head.removeChild(link);
+        }
+
+        onerror = function() {
+          clear();
+          done();
+        }
+
+        onload = function() {
+          clear();
+          chai.assert.fail('load event', 'error event', 'load event should not be fired');
+        }
+
+        link.addEventListener('load', onload);
+        link.addEventListener('error', onerror);
+
+        document.head.appendChild(link);
+
+      });
+
+      test('error event is fired when loading the same location failed twice', function(done) {
+
+        var createImportLink = function(done) {
+
+          var link = document.createElement('link');
+          link.rel = 'import';
+          link.href= 'imports/error-4.html';
+
+          var clear, onload, onerror;
+
+          clear = function() {
+            link.removeEventListener('load', onload);
+            link.removeEventListener('error', onerror);
+            document.head.removeChild(link);
+          }
+
+          onerror = function() {
+            clear();
+            done();
+          }
+
+          onload = function() {
+            clear();
+            chai.assert.fail('load event', 'error event', 'load event should not be fired');
+          }
+
+          link.addEventListener('load', onload);
+          link.addEventListener('error', onerror);
+
+          document.head.appendChild(link);
+
+        }
+
+        createImportLink(function() {
+          createImportLink(function() {
+            done();
+          });
+        });
+
+      });
     </script>
   </body>
 </html>

--- a/tests/HTMLImports/html/imports/load-3.html
+++ b/tests/HTMLImports/html/imports/load-3.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/tests/HTMLImports/html/imports/load-4.html
+++ b/tests/HTMLImports/html/imports/load-4.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->


### PR DESCRIPTION
When an import was not successfully loaded in first place, the load event should not be dispatched on the element if trying to import a second time. This change checks there is actually content loaded before invoking the load event.

Tests were added according to the [notes in the webcomponents import spec](https://w3c.github.io/webcomponents/spec/imports/#fetching-import)