### PR TITLE
Copy custom event properties to IE Event shim

### DIFF
--- a/src/WebComponents/dom.js
+++ b/src/WebComponents/dom.js
@@ -79,8 +79,20 @@
 
   var isIE = /Trident/.test(navigator.userAgent);
 
+  var copyOwnProperties = function(src, dest) {
+    var origPropertyNames = Object.getOwnPropertyNames(src);
+    for (var i = 0; i < origPropertyNames.length; i++) {
+      var origPropertyName = origPropertyNames[i];
+      var propertyDescriptor = Object.getOwnPropertyDescriptor(src, origPropertyName);
+      if (propertyDescriptor.writable) {
+        dest[origPropertyNames[i]] = src[origPropertyNames[i]];
+      }
+    }
+  };
+
   // CustomEvent constructor shim
   if (!window.CustomEvent || isIE && (typeof window.CustomEvent !== 'function')) {
+    var origCustomEvent = window.CustomEvent;
     window.CustomEvent = function(inType, params) {
       params = params || {};
       var e = document.createEvent('CustomEvent');
@@ -88,6 +100,7 @@
       return e;
     };
     window.CustomEvent.prototype = window.Event.prototype;
+    copyOwnProperties(origCustomEvent, window.CustomEvent);
   }
 
   // Event constructor shim
@@ -100,6 +113,7 @@
       return e;
     };
     window.Event.prototype = origEvent.prototype;
+    copyOwnProperties(origEvent, window.Event);
   }
 
 })(window.WebComponents);

--- a/tests/WebComponents/html/dom.html
+++ b/tests/WebComponents/html/dom.html
@@ -12,6 +12,10 @@
 <head>
   <meta charset="UTF-8">
   <title>WebComponents dom tests</title>
+  <script>
+    Event.customProperty = 'property';
+    CustomEvent.customProperty = 'property';
+  </script>
   <script src="../../../../web-component-tester/browser.js"></script>
   <script src="../../../webcomponents.js"></script>
 </head>
@@ -83,7 +87,7 @@
       assert.isFalse(e.cancelable);
     });
 
-    test('event defaultPrevented', function() {
+    test('Event defaultPrevented', function() {
       var e = new Event('foo', {cancelable: true});
       e.preventDefault();
       assert.isTrue(e.defaultPrevented);
@@ -97,6 +101,14 @@
       assert.isTrue(e.defaultPrevented);
       // call again, just in case
       assert.doesNotThrow(function() {e.preventDefault(); });
+    });
+
+    test('Event custom property', function() {
+      assert.equal(Event.customProperty, 'property');
+    });
+
+    test('CustomEvent custom property', function() {
+      assert.equal(CustomEvent.customProperty, 'property');
     });
 
     test('dispatch and prevent', function() {


### PR DESCRIPTION
WebComponents Event shim has a conflict with [PrototypeJs Event
object][1]. WebComponents Event shim create a new Event, which clears own properties of PrototypeJS
Event object.

This can be fixed by copying own properties of original Event to the shim Event.

[1]: http://api.prototypejs.org/dom/Event/