### PR TITLE
Fire WebComponentsReady once. Remove HTMLImports stub

### DIFF
--- a/tests/ce-import-upgrade-async.html
+++ b/tests/ce-import-upgrade-async.html
@@ -26,7 +26,7 @@
           // order expected
           assert.deepEqual(a1DocsList, ['a1-instance.html', 'a1-reference.html']);
           // style applied at upgrade time
-          if (!HTMLImports.useNative) {
+          if (window.HTMLImports) {
             assert.isTrue(styleAppliedToDocument);
           }
           done();

--- a/tests/ce-import.html
+++ b/tests/ce-import.html
@@ -30,6 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         HTMLImports.whenReady(function() {
           assert.isTrue(xfoo.isCreated, 'element in main document, registered in dynamic import is upgraded');
           var ix = link.import.querySelector('x-foo');
+          assert.equal(HTMLImports.importForElement(ix), link.import, 'import for element should be link import');
           assert.isTrue(ix.isCreated, 'element in import, registered in dynamic import is upgraded');
           done();
         });

--- a/tests/ce-import.html
+++ b/tests/ce-import.html
@@ -26,11 +26,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         link.rel = 'import';
         link.href = 'imports/element-import.html';
         document.head.appendChild(link);
-
-        HTMLImports.whenReady(function() {
+        link.addEventListener('load', function() {
           assert.isTrue(xfoo.isCreated, 'element in main document, registered in dynamic import is upgraded');
           var ix = link.import.querySelector('x-foo');
-          assert.equal(HTMLImports.importForElement(ix), link.import, 'import for element should be link import');
           assert.isTrue(ix.isCreated, 'element in import, registered in dynamic import is upgraded');
           done();
         });

--- a/tests/ce-upgradedocumenttree.html
+++ b/tests/ce-upgradedocumenttree.html
@@ -38,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       test('upgraded document tree', function(done) {
-        if (CustomElements.useNative || HTMLImports.useNative) {
+        if (CustomElements.useNative || !window.HTMLImports) {
           return done();
         } else {
           window.addEventListener('WebComponentsReady', function() {

--- a/tests/load.html
+++ b/tests/load.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('Loader', function() {
         test('expected boot', function() {
           assert.equal(window.webComponentsReadyCount, 1, 'failed to fire WebComponentsReady');
-          if (!window.HTMLImports.useNative) {
+          if (window.HTMLImports) {
             assert.ok(window.importsOk, 'WebComponentsReady without HTMLImportsLoaded');
           }
           assert.ok(window.importTest, 'import failed to set global value');

--- a/tests/load.html
+++ b/tests/load.html
@@ -16,8 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       window.addEventListener('HTMLImportsLoaded', function() {
         window.importsOk = true;
       });
+      window.webComponentsReadyCount = 0;
       window.addEventListener('WebComponentsReady', function() {
-        window.webComponentsReady = true;
+        window.webComponentsReadyCount++;
       });
     </script>
     <script src="../webcomponents-loader.js"></script>
@@ -28,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       suite('Loader', function() {
         test('expected boot', function() {
-          assert.ok(window.webComponentsReady, 'failed to fire WebComponentsReady');
+          assert.equal(window.webComponentsReadyCount, 1, 'failed to fire WebComponentsReady');
           if (!window.HTMLImports.useNative) {
             assert.ok(window.importsOk, 'WebComponentsReady without HTMLImportsLoaded');
           }

--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -11,29 +11,7 @@
 (function() {
   // Feature detect which polyfill needs to be imported.
   let polyfills = [];
-  if ('import' in document.createElement('link')) {
-    // Stub out HTMLImports if we're using native imports.
-    window.HTMLImports = {
-      useNative: true,
-      importForElement: function(el) {
-        return el.ownerDocument !== document ? el.ownerDocument : null;
-      },
-      whenReady: function(callback) {
-        // When native imports boot, the are "ready" the first rAF after
-        // the document becomes interactive, so wait for the correct state change.
-        if (document.readyState === 'loading') {
-          document.addEventListener('readystatechange', function once() {
-            document.removeEventListener('readystatechange', once);
-            HTMLImports.whenReady(callback);
-          });
-        } else if (document.readyState === 'interactive') {
-          requestAnimationFrame(callback);
-        } else {
-          callback();
-        }
-      }
-    };
-  } else {
+  if (!('import' in document.createElement('link'))) {
     polyfills.push('hi');
   }
   if (!('attachShadow' in Element.prototype) || (window.ShadyDOM && window.ShadyDOM.force)) {
@@ -69,10 +47,8 @@
   // is removed. Addressing this is blocked on
   // https://github.com/webcomponents/shadycss/issues/46.
   if (polyfills[0] === 'none') {
-    HTMLImports.whenReady(function() {
-      requestAnimationFrame(function() {
-        window.dispatchEvent(new CustomEvent('WebComponentsReady'));
-      });
+    requestAnimationFrame(function() {
+      window.dispatchEvent(new CustomEvent('WebComponentsReady'));
     });
   }
 })();

--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -59,6 +59,11 @@
   // https://github.com/webcomponents/shadycss/issues/46.
   if (!polyfills.length) {
     polyfills.push('none');
+    HTMLImports.whenReady(function() {
+      requestAnimationFrame(function() {
+        window.dispatchEvent(new CustomEvent('WebComponentsReady'));
+      })
+    });
   } else if (polyfills.length === 4) {  // hi-ce-sd-pf is actually called lite.
     polyfills = ['lite'];
   }
@@ -72,10 +77,4 @@
     newScript.src = url;
     document.head.appendChild(newScript);
   }
-
-  HTMLImports.whenReady(function() {
-    requestAnimationFrame(function() {
-      window.dispatchEvent(new CustomEvent('WebComponentsReady'));
-    })
-  });
 })();


### PR DESCRIPTION
Ensure `WebComponentsReady` is fired once. Previously it would be fired 2 times when using `webcomponents-loader.js`:
- one is fired by [`webcomponents-loader.js` itself](https://github.com/webcomponents/webcomponentsjs/blob/v1/webcomponents-loader.js#L76)
- another is fired by any bundle that loads [`post-polyfill.js`](https://github.com/webcomponents/webcomponentsjs/blob/v1/src/post-polyfill.js#L48), e.g. [hi-ce bundle](https://github.com/webcomponents/webcomponentsjs/blob/v1/entrypoints/webcomponents-hi-ce-index.js#L25)

Removed `HTMLImports` stub, updated tests accordingly.