### PR TITLE
Fix license value in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   "keywords": [
     "webcomponents"
   ],
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "ignore": [],
   "devDependencies": {
     "web-component-tester": "^5",


### PR DESCRIPTION
According to bower.json spec (https://github.com/bower/spec/blob/master/json.md#license), "license" value must be one of SPDX license identifiers (https://spdx.org/licenses), "BSD" is not a valid SPDX identifier.