### PR TITLE
Clarify purpose of custom-elements-es5-adapter.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ elements, etc.). Here's an example:
 ```
 
 ## `custom-elements-es5-adapter.js`
-According to the spec, Custom Elements must be ES6 classes (https://html.spec.whatwg.org/multipage/scripting.html#custom-element-conformance). Since most projects need to support a wide range of browsers that don't necessary support ES6, it may make sense to compile your project to ES5. However, ES5-style custom element classes will **not** work with native Custom Elements because ES5-style classes cannot properly extend ES6 classes, like `HTMLElement`.
+According to the spec, Custom Elements must be ES6 classes (https://html.spec.whatwg.org/multipage/scripting.html#custom-element-conformance). Since most projects need to support a wide range of browsers that don't necessary support ES6, it may make sense to compile your project to ES5. However, if you do so, ES5-style custom element classes will now **not** work with native Custom Elements because ES5-style classes cannot properly extend ES6 classes, like `HTMLElement`.
 
-To work around this, load `custom-elements-es5-adapter.js` before declaring new Custom Elements.
+As a workaround, if your project has been compiled to ES5, load `custom-elements-es5-adapter.js` before declaring new Custom Elements.
 
 **The adapter must NOT be compiled.**
 


### PR DESCRIPTION
There is some confusion as to the purpose of the ES5 adapter (e.g., https://github.com/webcomponents/webcomponentsjs/issues/749) This clarifies that the adapter is not an ES5 polyfill but rather that it should be used if a project has been compiled to ES5.