### PR TITLE
Support inlining webcomponents-loader via WebComponents.root property

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Here's an example:
 </script>
 ```
 
+If you have inlined the source of `webcomponent-loader.js`, then you should specify `window.WebComponents.root` as the root from which to load the polyfills. For example:
+
+```html
+<script>
+  window.WebComponents = window.WebComponents || {};
+  window.WebComponents.root = 'bower_components/webcomponentsjs/';
+</script>
+```
+
 ## `custom-elements-es5-adapter.js`
 According to the spec, Custom Elements must be ES6 classes (https://html.spec.whatwg.org/multipage/scripting.html#custom-element-conformance). Since most projects need to support a wide range of browsers that don't necessary support ES6, it may make sense to compile your project to ES5. However, ES5-style custom element classes will **not** work with native Custom Elements because ES5-style classes cannot properly extend ES6 classes, like `HTMLElement`.
 
@@ -150,7 +159,7 @@ window.addEventListener('WebComponentsReady', function(e) {
   * [Custom element's constructor property is unreliable](#constructor)
   * [Contenteditable elements do not trigger MutationObserver](#contentedit)
   * [ShadyCSS: :host(.zot:not(.bar:nth-child(2))) doesn't work](#nestedparens)
-  
+
 ### ShadowDOM CSS is not encapsulated out of the box <a id="shadycss"></a>
 The ShadowDOM polyfill is not able to encapsulate CSS in ShadowDOM out of the box. You need to use specific code from the ShadyCSS library, included with the polyfill. See [ShadyCSS instructions](https://github.com/webcomponents/shadycss).
 

--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -35,17 +35,25 @@
   }
 
   if (polyfills.length) {
-    var script = document.querySelector('script[src*="' + name +'"]');
+    var url;
+    var polyfillFile = 'webcomponents-' + polyfills.join('-') + '.js';
+
+    if (window.WebComponents.root) {
+      url = window.WebComponents.root + polyfillFile;
+    } else {
+      var script = document.querySelector('script[src*="' + name +'"]');
+      // Load it from the right place.
+      url = script.src.replace(name, polyfillFile);
+    }
+
     var newScript = document.createElement('script');
-    // Load it from the right place.
-    var replacement = 'webcomponents-' + polyfills.join('-') + '.js';
-    var url = script.src.replace(name, replacement);
     newScript.src = url;
+
     // NOTE: this is required to ensure the polyfills are loaded before
     // *native* html imports load on older Chrome versions. This *is* CSP
     // compliant since CSP rules must have allowed this script to run.
     // In all other cases, this can be async.
-    if (document.readyState === 'loading' && ('import' in document.createElement('link'))) {
+    if (document.readyState === 'loading') {
       document.write(newScript.outerHTML);
     } else {
       document.head.appendChild(newScript);


### PR DESCRIPTION
Fixes https://github.com/webcomponents/webcomponentsjs/issues/801.

If a user inlines `webcomponents-loader.js` (via the Polymer-CLI for instance), then this will allow the loader to continue working so long as they specify a value for `window.WebComponents.root`.