### PR TITLE
Remove generating blank .map file for webcomponents-lite.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,15 +115,15 @@ gulp.task('debugify-sd-ce', () => {
 });
 
 gulp.task('closurify-hi', () => {
-  return closurify('webcomponents-hi')
+  return closurify('webcomponents-hi', true)
 });
 
 gulp.task('closurify-hi-ce', () => {
-  return closurify('webcomponents-hi-ce')
+  return closurify('webcomponents-hi-ce', true)
 });
 
 gulp.task('closurify-hi-sd-ce', () => {
-  return closurify('webcomponents-hi-sd-ce')
+  return closurify('webcomponents-hi-sd-ce', true)
 });
 
 gulp.task('closurify-hi-sd-ce-pf', () => {
@@ -131,7 +131,7 @@ gulp.task('closurify-hi-sd-ce-pf', () => {
 });
 
 gulp.task('closurify-sd-ce', () => {
-  return closurify('webcomponents-sd-ce')
+  return closurify('webcomponents-sd-ce', true)
 });
 
 function singleLicenseComment() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,15 +115,15 @@ gulp.task('debugify-sd-ce', () => {
 });
 
 gulp.task('closurify-hi', () => {
-  return closurify('webcomponents-hi', true)
+  return closurify('webcomponents-hi', false, true)
 });
 
 gulp.task('closurify-hi-ce', () => {
-  return closurify('webcomponents-hi-ce', true)
+  return closurify('webcomponents-hi-ce', false, true)
 });
 
 gulp.task('closurify-hi-sd-ce', () => {
-  return closurify('webcomponents-hi-sd-ce', true)
+  return closurify('webcomponents-hi-sd-ce', false, true)
 });
 
 gulp.task('closurify-hi-sd-ce-pf', () => {
@@ -131,7 +131,7 @@ gulp.task('closurify-hi-sd-ce-pf', () => {
 });
 
 gulp.task('closurify-sd-ce', () => {
-  return closurify('webcomponents-sd-ce', true)
+  return closurify('webcomponents-sd-ce', false, true)
 });
 
 function singleLicenseComment() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ function debugify(sourceName, fileName, extraRollupOptions) {
   .pipe(gulp.dest('./'))
 }
 
-function closurify(sourceName, fileName) {
+function closurify(sourceName, fileName, sourceMapsLoad) {
   if (!fileName) {
     fileName = sourceName;
   }
@@ -70,17 +70,25 @@ function closurify(sourceName, fileName) {
     entry: `entrypoints/${sourceName}-index.js`,
     format: 'iife',
     moduleName: 'webcomponents',
-    sourceMap: true,
+    sourceMap: sourceMapsLoad,
     context: 'window'
   };
 
-  return rollup(rollupOptions)
-  .pipe(source(`${sourceName}-index.js`, 'entrypoints'))
-  .pipe(buffer())
-  .pipe(sourcemaps.init({loadMaps: true}))
-  .pipe(closure(closureOptions))
-  .pipe(sourcemaps.write('.'))
-  .pipe(gulp.dest('.'));
+  if (!sourceMapsLoad) {
+    return rollup(rollupOptions)
+    .pipe(source(`${sourceName}-index.js`, 'entrypoints'))
+    .pipe(buffer())
+    .pipe(closure(closureOptions))
+    .pipe(gulp.dest('.'));
+  } else {
+    return rollup(rollupOptions)
+    .pipe(source(`${sourceName}-index.js`, 'entrypoints'))
+    .pipe(buffer())
+    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(closure(closureOptions))
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest('.'));
+  }
 }
 
 gulp.task('debugify-hi', () => {
@@ -119,7 +127,7 @@ gulp.task('closurify-hi-sd-ce', () => {
 });
 
 gulp.task('closurify-hi-sd-ce-pf', () => {
-  return closurify('webcomponents-hi-sd-ce-pf', 'webcomponents-lite')
+  return closurify('webcomponents-hi-sd-ce-pf', 'webcomponents-lite', false)
 });
 
 gulp.task('closurify-sd-ce', () => {


### PR DESCRIPTION
It was failing to load correctly due to a blank .map file.

As it's blank lets remove it for webcomponents-lite.js.