### PR TITLE
fix the issue with non-inspectable polyfills in dev tools

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ function closurify(sourceName, fileName) {
   };
 
   return rollup(rollupOptions)
-  .pipe(source(`${sourceName}-index.js`, 'entrypoints'))
+  .pipe(source(`${sourceName}-bundle.js`))
   .pipe(buffer())
   .pipe(sourcemaps.init({loadMaps: true}))
   .pipe(closure(closureOptions))


### PR DESCRIPTION
Due to a misconfiguration of the gulp build pipeline, the source maps for all minified polyfill files are generated without including the contents of the original source files. This causes the polyfills to be non-inspectable in the browser developer tools (compare the before and after screenshots below).

Before:
<img width="773" alt="before-sources-are-not-inspectable" src="https://user-images.githubusercontent.com/22416150/31547930-d14e75a4-b031-11e7-8707-ec68ffd51c63.png">

After:
<img width="771" alt="after-sources-are-inspectable" src="https://user-images.githubusercontent.com/22416150/31547542-6924c04c-b030-11e7-9d9b-266ad82be074.png">

Fixes #812 
