### PR TITLE
Redirect webcomponents-hi-sd.js to webcomponents-hi-sd-ce.js

### DIFF
--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -39,6 +39,12 @@
     var newScript = document.createElement('script');
     // Load it from the right place.
     var replacement = 'webcomponents-' + polyfills.join('-') + '.js';
+    
+    // webcomponents-hi-sd.js does currently not exist
+    if (replacement === 'webcomponents-hi-sd.js') {
+      replacement = 'webcomponents-hi-sd-ce.js'
+    }
+    
     var url = script.src.replace(name, replacement);
     newScript.src = url;
     // NOTE: this is required to ensure the polyfills are loaded before


### PR DESCRIPTION
Interim solution for #817 because anything is better that having it not work at all. Currently `webcomponents-hi-sd.js` does not exist, this consequently leads to a 404. This PR just fixes this by loading `webcomponents-hi-sd-ce.js` even though the custom elements polyfill isn't need.