### PR TITLE
Add JSBin starter template for issue reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Want to contribute to webcomponents.js? Great!
 
 We are more than happy to accept external contributions to the project in the form of [bug reports](../../issues) and pull requests.
 
-For any bug report, please use [this jsbin](http://jsbin.com/ceqicowuli/edit?html,console,output) to provide a concrete reproduction case that we can debug.
+For any bug report, please use [this jsbin](http://jsbin.com/birajez/edit?html,console,output) to provide a concrete reproduction case that we can debug.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Want to contribute to webcomponents.js? Great!
 
 We are more than happy to accept external contributions to the project in the form of [bug reports](../../issues) and pull requests.
 
+For any bug report, please use [this jsbin](http://jsbin.com/ceqicowuli/edit?html,console,output) to provide a concrete reproduction case that we can debug.
+
 ## Contributor License Agreement
 
 Before we can accept patches, there's a quick web form you need to fill out.


### PR DESCRIPTION
To make sure every issue that is opened has a jsbin that we can debug, at a starter template with a very basic setup. It has a template, styles it with ShadyCSS and defines a custom element.