### PR TITLE
Fixes #923

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: required
 dist: trusty
-node_js: stable
+node_js: 8
 addons:
   firefox: latest
   apt:

--- a/tests/template-and-CE.html
+++ b/tests/template-and-CE.html
@@ -62,6 +62,111 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert(foundTemplate);
         });
       });
+
+      suite('Template', function() {
+        var template;
+        suiteSetup(function() {
+          template = document.querySelector('template');
+        });
+
+        var canInnerHTML = (function() {
+          var el = document.createElement('div');
+          try {
+            Object.defineProperty(el, 'innerHTML', {
+              get: function(){},
+              set: function(){}
+            });
+            return true;
+          } catch(e) {
+            return false;
+          }
+        })();
+
+        function setupTemplate(template, string) {
+          if (canInnerHTML) {
+            template.innerHTML = string;
+          } else {
+            var el = document.createElement('div');
+            el.innerHTML = string;
+            var nodes = Array.prototype.slice.call(el.childNodes, 0);
+            for (var i = 0; i < nodes.length; i++) {
+              template.content.appendChild(nodes[i]);
+            }
+          }
+        }
+
+        test('clone', function() {
+          var imp = document.createElement('template');
+          var s = '<div>Hi</div>';
+          setupTemplate(imp, s);
+          var clone = imp.cloneNode();
+          assert.notEqual(clone, imp, 'element is not cloned');
+          assert.isDefined(clone.content, 'cloned template content dne');
+          assert.equal(clone.content.childNodes.length, 0,
+              'non-deep cloned template.content is not empty');
+          var deepClone = imp.cloneNode(true);
+          assert.equal(deepClone.content.childNodes.length, 1,
+              'deep cloned template.content is empty');
+          assert.notEqual(imp.content.firstChild, deepClone.content.firstChild,
+              'cloned content is not different from source');
+        });
+
+        test('clone nested', function() {
+          var imp = document.createElement('template');
+          var s = 'a<template id="a">b<template id="b">c<template id="c">d</template></template></template>';
+          setupTemplate(imp, s);
+          var clone = imp.cloneNode(false);
+          assert.notEqual(clone, imp, 'element is not cloned');
+          assert.isDefined(clone.content, 'cloned template content dne');
+          assert.equal(clone.content.childNodes.length, 0,
+              'non-deep cloned template.content is not empty');
+          var deepClone = imp.cloneNode(true);
+          assert.equal(deepClone.content.childNodes.length, 2,
+              'deep cloned template.content is empty');
+          assert.notEqual(imp.content.firstChild, deepClone.content.firstChild,
+              'cloned content is not different from source');
+          var nested = deepClone.content.lastChild;
+          assert.isDefined(nested.content, 'nested cloned template content dne');
+          assert.equal(nested.content.childNodes.length, 2,
+              'deep cloned template.content is empty');
+          nested = nested.content.lastChild;
+          assert.isDefined(nested, 'nested cloned template content dne');
+          assert.equal(nested.content.childNodes.length, 2,
+              'deep cloned template.content is empty');
+          nested = nested.content.lastChild;
+          assert.isDefined(nested, 'nested cloned template content dne');
+          assert.equal(nested.content.childNodes.length, 1,
+              'deep cloned template.content is empty');
+        });
+
+        test('clone node containing templates', function() {
+          var imp = document.createElement('div');
+          var t = document.createElement('template');
+          var s = 'a<template id="a">b<template id="b">c<template id="c">d</template></template></template>';
+          setupTemplate(t, s);
+          imp.appendChild(t);
+          var impClone = imp.cloneNode(true);
+          imp = imp.firstChild;
+          var deepClone = impClone.firstChild;
+          assert.equal(deepClone.content.childNodes.length, 2,
+              'deep cloned template.content is empty');
+          assert.notEqual(imp.content.firstChild, deepClone.content.firstChild,
+              'cloned content is not different from source');
+          var nested = deepClone.content.lastChild;
+          assert.isDefined(nested.content, 'nested cloned template content dne');
+          assert.equal(nested.content.childNodes.length, 2,
+              'deep cloned template.content is empty');
+          nested = nested.content.lastChild;
+          assert.isDefined(nested, 'nested cloned template content dne');
+          assert.equal(nested.content.childNodes.length, 2,
+              'deep cloned template.content is empty');
+          nested = nested.content.lastChild;
+          assert.isDefined(nested, 'nested cloned template content dne');
+          assert.equal(nested.content.childNodes.length, 1,
+              'deep cloned template.content is empty');
+        });
+
+      });
     </script>
   </body>
 </html>

--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -26,11 +26,29 @@
   if (!window.customElements || window.customElements.forcePolyfill) {
     polyfills.push('ce');
   }
+
+  var needsTemplate = (function() {
+    // no real <template> because no `content` property (IE and older browsers)
+    var t = document.createElement('template');
+    if (!('content' in t)) {
+      return true;
+    }
+    // broken doc fragment (older Edge)
+    if (!(t.content.cloneNode() instanceof DocumentFragment)) {
+      return true;
+    }
+    // broken <template> cloning (Edge up to at least version 17)
+    var t2 = document.createElement('template');
+    t2.content.appendChild(document.createElement('div'));
+    t.content.appendChild(t2);
+    var clone = t.cloneNode(true);
+    return (clone.content.childNodes.length === 0 ||
+        clone.content.firstChild.content.childNodes.length === 0);
+  })();
+
   // NOTE: any browser that does not have template or ES6 features
   // must load the full suite (called `lite` for legacy reasons) of polyfills.
-  if (!('content' in document.createElement('template')) || !window.Promise || !Array.from ||
-    // Edge has broken fragment cloning which means you cannot clone template.content
-    !(document.createDocumentFragment().cloneNode() instanceof DocumentFragment)) {
+  if (!window.Promise || !Array.from || needsTemplate) {
     polyfills = ['lite'];
   }
 


### PR DESCRIPTION
Loader: Include all tests from the Template polyfill to see if it's needed.

Previously Edge had (1) broken DocumentFragment cloning, and (2) broken Template.content cloning. The loader was only checking (1) but Edge 17 fixes (1) but not (2) so now we check both issues.