### PR TITLE
Ensure the property descriptor is not undefined

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -15,7 +15,10 @@ import '../node_modules/polyfill-library/polyfills/Symbol/iterator/polyfill.js';
 
 // overwrite Object.keys to filter out symbols
 Object.keys = function(obj) {
-  return Object.getOwnPropertyNames(obj).filter((name) => Object.getOwnPropertyDescriptor(obj, name).enumerable);
+  return Object.getOwnPropertyNames(obj).filter((name) => {
+    const prop = Object.getOwnPropertyDescriptor(obj, name);
+    return prop && prop.enumerable;
+  });
 };
 
 // implement iterators for IE 11

--- a/tests/symbol.html
+++ b/tests/symbol.html
@@ -80,6 +80,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.deepEqual(Object.keys(obj), ['a', 'b']);
         assert.deepEqual(Object.getOwnPropertySymbols(obj), [s1, s2]);
       });
+
+      // https://github.com/webcomponents/webcomponentsjs/issues/987
+      test('Object.keys does not throw on property with undefined descriptor', function() {
+        assert.doesNotThrow(() => Object.keys(window));
+      });
     })
   </script>
 </body>


### PR DESCRIPTION
Fixes #987

Note: event without this change, latest Closure compiler installed locally is adding this guard, as I mentioned already in [#987 (comment)](https://github.com/webcomponents/webcomponentsjs/issues/987#issuecomment-416151589)
But let's not rely on some tooling here to be more explicit.

See also #988 where I'm doing the `package-lock.json` update using npm 6.4.0