### PR TITLE
Set keepFnName in custom-elements-es5-adapter babel config (v1 branch)

### DIFF
--- a/custom-elements-es5-adapter.js
+++ b/custom-elements-es5-adapter.js
@@ -10,6 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function () {
 'use strict';
 
-(function(){if(void 0===window.Reflect||void 0===window.customElements||window.customElements.hasOwnProperty('polyfillWrapFlushCallback'))return;const a=HTMLElement;window.HTMLElement=function(){return Reflect.construct(a,[],this.constructor)},HTMLElement.prototype=a.prototype,HTMLElement.prototype.constructor=HTMLElement,Object.setPrototypeOf(HTMLElement,a);})();
+(function(){if(void 0===window.Reflect||void 0===window.customElements||window.customElements.hasOwnProperty('polyfillWrapFlushCallback'))return;const a=HTMLElement;window.HTMLElement=function HTMLElement(){return Reflect.construct(a,[],this.constructor)},HTMLElement.prototype=a.prototype,HTMLElement.prototype.constructor=HTMLElement,Object.setPrototypeOf(HTMLElement,a);})();
 
 }());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,7 +152,9 @@ gulp.task('closurify-sd', () => {
 })
 
 const babelOptions = {
-  presets: 'minify',
+  presets: [
+    ['minify', {'keepFnName': true}],
+  ],
 };
 
 gulp.task('debugify-ce-es5-adapter', () => {


### PR DESCRIPTION
Otherwise our HTMLElement definition loses its name.

Effectively we were un-doing the fix from https://github.com/webcomponents/custom-elements/commit/d32780ce115f56abe88a29252f3462a7e94bea61

cc @bicknellr 