### PR TITLE
Set keepFnName in custom-elements-es5-adapter babel config (v2)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,7 +156,9 @@ gulp.task('debugify-ce-es5-adapter', () => {
   const rollupOptions = {
     plugins: [
       babel({
-        presets: 'minify'
+        presets: [
+          ['minify', {'keepFnName': true}]
+        ],
       }),
       license({
         banner: {


### PR DESCRIPTION
Otherwise our HTMLElement definition loses its name.

Effectively we were un-doing the fix from webcomponents/custom-elements@d32780c

v2 version of https://github.com/webcomponents/webcomponentsjs/pull/1031