### PR TITLE
docs(readme): use semver range for CDN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For browsers that need it, there are also some minor polyfills included:
 npm install @webcomponents/webcomponentsjs
 ```
 
-You can also load the code from a CDN such as unpkg: https://unpkg.com/@webcomponents/webcomponentsjs@2.0.0/
+You can also load the code from a CDN such as unpkg: https://unpkg.com/@webcomponents/webcomponentsjs@^2/
 
 ### Using `webcomponents-bundle.js`
 


### PR DESCRIPTION
Changes the unpkg URL to resolve to the latest version within the current major, rather than pinning to 2.0.0.

_Note_: Intentionally not set to `@latest` since that might result in people unknowingly experiencing breaking changes if and when a next major is released.