### PR TITLE
Fix loader process flow for no-polyfills cases

### DIFF
--- a/tests/async-loader-no-polyfills.html
+++ b/tests/async-loader-no-polyfills.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+<head>
+  <!--
+    This test should be run only for spec-compliant browsers that require no polyfills.
+    When Loader is used async, we expect `WebComponentsReady` event to fire after all
+    waitFor() callbacks are resolved.
+  -->
+  <title>Test loader async/no-polyfills cases</title>
+  <meta charset="UTF-8">
+  <script src="../webcomponents-loader.js" defer></script>
+  <script src="./wct-config.js"></script>
+  <script>
+    WCT.waitForFrameworks = false;
+    window._wctCallback = function() {};
+  </script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+  <script>
+    // Define mock load function that takes `duration` to resolve.
+    window.mockLoadCount = 0;
+    window.mockLoad = function(duration) {
+      return new Promise(function(resolve) {
+        window.mockLoadCount++;
+        setTimeout(resolve, duration);
+      });
+    };
+  </script>
+  <script type="module">
+    WebComponents.waitFor(() => {
+      return mockLoad(1000).then(() => {
+        window.mockModule1Loaded = true;
+      });
+    });
+  </script>
+  <script type="module">
+    WebComponents.waitFor(() => {
+      return mockLoad(500).then(() => {
+        window.mockModule2Loaded = true;
+      })
+    });
+  </script>
+</head>
+
+<body>
+  <script>
+    suite('Loader async/no-polyfills tests', function () {
+      test('Modules are loaded after WCR fires', function(done) {
+        window.addEventListener('WebComponentsReady', function() {
+          assert.isOk(window.mockModule1Loaded);
+          assert.isOk(window.mockModule2Loaded);
+          done();
+        });
+      });
+      test('waitFor() callbacks are run exactly once', function() {
+        // We expect mockLoadCount to be 2, since we defined two `waitFor` cbs.
+        assert.equal(window.mockLoadCount, 2);
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/tests/async-loader-no-polyfills.html
+++ b/tests/async-loader-no-polyfills.html
@@ -53,13 +53,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <body>
   <script>
-    suite('Loader async/no-polyfills tests', function () {
+    suite('Loader async/no-polyfills tests', function() {
       test('Modules are loaded after WCR fires', function(done) {
-        window.addEventListener('WebComponentsReady', function() {
+        var tested = false;
+        var assertModulesLoaded = function() {
+          tested = true;
           assert.isOk(window.mockModule1Loaded);
           assert.isOk(window.mockModule2Loaded);
           done();
-        });
+        };
+        window.addEventListener('WebComponentsReady', assertModulesLoaded);
+        // An issue with WCT on Safari 10 causes `document.readyState` to be wrongly resolved as `complete`.
+        // This causes WCR to fire immediately before the event listener is defined, causing a timeout.
+        // As a workaround, we run a timer to check if WCR has been missed, then run the assertions.
+        setTimeout(function() {
+          if (!tested && WebComponents.ready) {
+            assertModulesLoaded();
+          }
+        }, 4000);
       });
       test('waitFor() callbacks are run exactly once', function() {
         // We expect mockLoadCount to be 2, since we defined two `waitFor` cbs.

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -43,5 +43,47 @@
   } catch (e) {} // eslint-disable-line no-empty
 </script>
 <script>
+  // Include `async-loader-no-polyfills` test only for browsers that require no polyfills.
+  // Feature-detection tests are from `webcomponents-loader.js`.
+
+  var polyfills = [];
+  if (!('attachShadow' in Element.prototype && 'getRootNode' in Element.prototype) ||
+    (window.ShadyDOM && window.ShadyDOM.force)) {
+    polyfills.push('sd');
+  }
+  if (!window.customElements || window.customElements.forcePolyfill) {
+    polyfills.push('ce');
+  }
+
+  var needsTemplate = (function() {
+    // no real <template> because no `content` property (IE and older browsers)
+    var t = document.createElement('template');
+    if (!('content' in t)) {
+      return true;
+    }
+    // broken doc fragment (older Edge)
+    if (!(t.content.cloneNode() instanceof DocumentFragment)) {
+      return true;
+    }
+    // broken <template> cloning (Edge up to at least version 17)
+    var t2 = document.createElement('template');
+    t2.content.appendChild(document.createElement('div'));
+    t.content.appendChild(t2);
+    var clone = t.cloneNode(true);
+    return (clone.content.childNodes.length === 0 ||
+        clone.content.firstChild.content.childNodes.length === 0);
+  })();
+
+  // NOTE: any browser that does not have template or ES6 features
+  // must load the full suite of polyfills.
+  if (!window.Promise || !Array.from || !window.URL || !window.Symbol || needsTemplate) {
+    polyfills = ['sd-ce-pf'];
+  }
+
+  if (!polyfills.length) {
+    window.suites.push('async-loader-no-polyfills.html');
+  }
+</script>
+<script>
   WCT.loadSuites(window.suites);
 </script>

--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -76,15 +76,13 @@
 
   function runWhenLoadedFns() {
     allowUpgrades = false;
-    var done = function() {
-      allowUpgrades = true;
-      whenLoadedFns.length = 0;
-      flushFn && flushFn();
-    };
-    return Promise.all(whenLoadedFns.map(function(fn) {
+    var fnsMap = whenLoadedFns.map(function(fn) {
       return fn instanceof Function ? fn() : fn;
-    })).then(function() {
-      done();
+    });
+    whenLoadedFns = [];
+    return Promise.all(fnsMap).then(function() {
+      allowUpgrades = true;
+      flushFn && flushFn();
     }).catch(function(err) {
       console.error(err);
     });

--- a/webcomponents-loader.js
+++ b/webcomponents-loader.js
@@ -18,8 +18,7 @@
    *
    * - Synchronous script, no polyfills needed
    *   - wait for `DOMContentLoaded`
-   *   - run callbacks passed to `waitFor`
-   *   - fire WCR event
+   *   - fire WCR event, as there could not be any callbacks passed to `waitFor`
    *
    * - Synchronous script, polyfills needed
    *   - document.write the polyfill bundle
@@ -29,7 +28,9 @@
    *   - fire WCR event
    *
    * - Asynchronous script, no polyfills needed
-   *   - fire WCR event, as there could not be any callbacks passed to `waitFor`
+   *   - wait for `DOMContentLoaded`
+   *   - run callbacks passed to `waitFor`
+   *   - fire WCR event
    *
    * - Asynchronous script, polyfills needed
    *   - Append the polyfill bundle script
@@ -168,9 +169,10 @@
       document.head.appendChild(newScript);
     }
   } else {
-    polyfillsLoaded = true;
+    // if readyState is 'complete', script is loaded imperatively on a spec-compliant browser, so just fire WCR
     if (document.readyState === 'complete') {
-      fireEvent()
+      polyfillsLoaded = true;
+      fireEvent();
     } else {
       // this script may come between DCL and load, so listen for both, and cancel load listener if DCL fires
       window.addEventListener('load', ready);


### PR DESCRIPTION
Hi @TimvdLippe, 

This fixes #1056. Some notes are:

1. A non-racy implementation of `runWhenLoadedFns()`.

2. For async/no-polyfills cases, we batch all `waitFor()` callbacks and run them in parallel upon the `DCL` event, then fire the `WCR` event after all promises resolve. 

3. For sync/no-polyfills cases, we simply fire the `WCR` event after `DCL`, because we are assured at that point that all CEs will have been defined. 

4. We actually run the same code block in (2) and (3). This works because there cannot possibly be `waitFor` defined in sync cases.

5. Could you check if tests are passing for Edge? I don't have immediate access to a Windows machine..

Thanks so much,
Jason

 