### PR TITLE
Remove old and unused externs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 custom-elements-es5-adapter.js
 webcomponents-bundle.js*
 bundles/**/*
+
+# For testing whether modifications change the built outputs
+comparison/
+new_comparison/

--- a/externs/webcomponents.js
+++ b/externs/webcomponents.js
@@ -9,19 +9,9 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-var require;
-var global;
-var ES6Promise;
-var process;
-var define;
-var module;
-var exports;
 
 var ShadyDOM;
 var WebComponents;
-
-/** @type {!Function} */
-Promise.cast;
 
 /** @type {function()} */
 HTMLTemplateElement.bootstrap;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test": "wct",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
     "prepack": "npm run build",
-    "clean": "gulp clean"
+    "clean": "gulp clean",
+    "snapshot": "rm -rf comparison && mkdir comparison && cp -r webcomponents-bundle.js custom-elements-es5-adapter.js bundles comparison",
+    "compare": "npm run build && rm -rf new_comparison && mkdir new_comparison && cp -r webcomponents-bundle.js custom-elements-es5-adapter.js bundles new_comparison && diff -r comparison/ new_comparison/"
   },
   "homepage": "https://webcomponents.org/polyfills",
   "devDependencies": {


### PR DESCRIPTION
All but `define` don't change the output at all, and `define` only appears to change local variables named 'define'. It looks like these are a holdover from when there was UMD or something in the build.