### PR TITLE
Modernize closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 custom-elements-es5-adapter.js
 webcomponents-bundle.js*
 bundles/**/*
+
+# For testing whether modifications change the built outputs
+comparison/
+new_comparison/

--- a/externs/webcomponents.js
+++ b/externs/webcomponents.js
@@ -9,19 +9,9 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-var require;
-var global;
-var ES6Promise;
-var process;
-var define;
-var module;
-var exports;
 
 var ShadyDOM;
 var WebComponents;
-
-/** @type {!Function} */
-Promise.cast;
 
 /** @type {function()} */
 HTMLTemplateElement.bootstrap;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,6 @@ function closurify(sourceName, fileName) {
 
   const closureOptions = {
     compilation_level: 'ADVANCED',
-    language_in: 'ES6_STRICT',
     language_out: 'ES5_STRICT',
     isolation_mode: 'NONE',
     output_wrapper_file: 'closure-output.txt',
@@ -73,22 +72,15 @@ function closurify(sourceName, fileName) {
     module_resolution: 'NODE',
     entry_point: `entrypoints/${sourceName}-index.js`,
     dependency_mode: 'STRICT',
-    process_common_js_modules: true,
-    externs: [
-      'externs/webcomponents.js',
-      'node_modules/@webcomponents/custom-elements/externs/custom-elements.js',
-      'node_modules/@webcomponents/shadycss/externs/shadycss-externs.js',
-      'node_modules/@webcomponents/shadydom/externs/shadydom.js'
-    ]
   };
 
   return gulp.src([
+      'externs/webcomponents.js',
       'entrypoints/*.js',
       'src/*.js',
       'node_modules/get-own-property-symbols/build/get-own-property-symbols.max.js',
       'node_modules/promise-polyfill/src/**/*.js',
       'node_modules/@webcomponents/**/*.js',
-      '!node_modules/@webcomponents/*/externs/*.js',
       '!node_modules/@webcomponents/*/node_modules/**'
     ], {base: './', follow: true})
   .pipe(sourcemaps.init())

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test": "wct",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
     "prepack": "npm run build",
-    "clean": "gulp clean"
+    "clean": "gulp clean",
+    "snapshot": "rm -rf comparison && mkdir comparison && cp -r webcomponents-bundle.js custom-elements-es5-adapter.js bundles comparison",
+    "compare": "npm run build && rm -rf new_comparison && mkdir new_comparison && cp -r webcomponents-bundle.js custom-elements-es5-adapter.js bundles new_comparison && diff -r comparison/ new_comparison/"
   },
   "homepage": "https://webcomponents.org/polyfills",
   "devDependencies": {


### PR DESCRIPTION
Builds on top of #1075

* externs are normal srcs
* no need for commonjs anymore
* use the default language_in of "all standards that closure has stable support for"
